### PR TITLE
Add Grounding DINO detector with HF Transformers

### DIFF
--- a/scripts/demo_grounding_dino.py
+++ b/scripts/demo_grounding_dino.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Minimal demo: run Grounding DINO on a single image."""
+
+import argparse
+import sys
+
+import cv2
+import supervision as sv
+
+from dino.detectors.grounding_dino import GroundingDINODetector
+
+DEFAULT_PROMPTS = ["person", "empty table", "plate of food", "chair"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Grounding DINO single-image demo")
+    parser.add_argument("--image", required=True, help="Path to input image")
+    parser.add_argument(
+        "--prompts",
+        nargs="+",
+        default=DEFAULT_PROMPTS,
+        help="Text prompts for detection",
+    )
+    parser.add_argument(
+        "--threshold", type=float, default=0.3, help="Box confidence threshold"
+    )
+    parser.add_argument("--output", default=None, help="Path to save annotated image")
+    args = parser.parse_args()
+
+    frame = cv2.imread(args.image)
+    if frame is None:
+        print(f"Error: cannot read image '{args.image}'", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Loading Grounding DINO...")
+    detector = GroundingDINODetector(box_threshold=args.threshold)
+    print(f"Device: {detector.device}")
+
+    print(f"Detecting with prompts: {args.prompts}")
+    detections = detector.detect(frame, args.prompts)
+
+    print(f"\nFound {len(detections)} detection(s):")
+    for i in range(len(detections)):
+        box = detections.xyxy[i]
+        conf = detections.confidence[i]
+        label = detections.data["class_name"][i] if "class_name" in detections.data else "unknown"
+        print(f"  [{i}] {label} ({conf:.2f}) at [{box[0]:.0f}, {box[1]:.0f}, {box[2]:.0f}, {box[3]:.0f}]")
+
+    if args.output:
+        box_annotator = sv.BoxAnnotator()
+        label_annotator = sv.LabelAnnotator()
+        labels = [
+            f"{detections.data['class_name'][i]} {detections.confidence[i]:.2f}"
+            for i in range(len(detections))
+        ]
+        annotated = box_annotator.annotate(scene=frame.copy(), detections=detections)
+        annotated = label_annotator.annotate(
+            scene=annotated, detections=detections, labels=labels
+        )
+        cv2.imwrite(args.output, annotated)
+        print(f"\nAnnotated image saved to: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dino/detectors/base.py
+++ b/src/dino/detectors/base.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+
+import numpy as np
+import supervision as sv
+
+
+class BaseDetector(ABC):
+    """Abstract base for all object detectors."""
+
+    @abstractmethod
+    def detect(self, frame: np.ndarray, prompts: list[str]) -> sv.Detections:
+        """Detect objects in a frame given text prompts.
+
+        Args:
+            frame: BGR image as numpy array (H, W, 3).
+            prompts: List of text descriptions to detect.
+
+        Returns:
+            sv.Detections with xyxy boxes, confidence scores, and class data.
+        """

--- a/src/dino/detectors/grounding_dino.py
+++ b/src/dino/detectors/grounding_dino.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import numpy as np
+import supervision as sv
+import torch
+from PIL import Image
+from transformers import AutoModelForZeroShotObjectDetection, AutoProcessor
+
+from dino.detectors.base import BaseDetector
+
+MODEL_ID = "IDEA-Research/grounding-dino-tiny"
+
+
+def _auto_device() -> str:
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+class GroundingDINODetector(BaseDetector):
+    """Grounding DINO detector via HuggingFace Transformers."""
+
+    def __init__(
+        self,
+        model_id: str = MODEL_ID,
+        device: str | None = None,
+        box_threshold: float = 0.3,
+        text_threshold: float = 0.25,
+    ):
+        self.device = device or _auto_device()
+        self.box_threshold = box_threshold
+        self.text_threshold = text_threshold
+
+        self.processor = AutoProcessor.from_pretrained(model_id)
+        self.model = AutoModelForZeroShotObjectDetection.from_pretrained(model_id).to(
+            self.device
+        )
+
+    def detect(self, frame: np.ndarray, prompts: list[str]) -> sv.Detections:
+        """Detect objects matching text prompts in a frame."""
+        image = Image.fromarray(frame[..., ::-1])  # BGR -> RGB
+        text = ". ".join(prompts) + "."
+
+        inputs = self.processor(images=image, text=text, return_tensors="pt").to(
+            self.device
+        )
+
+        with torch.no_grad():
+            outputs = self.model(**inputs)
+
+        results = self.processor.post_process_grounded_object_detection(
+            outputs,
+            inputs["input_ids"],
+            box_threshold=self.box_threshold,
+            text_threshold=self.text_threshold,
+            target_sizes=[image.size[::-1]],
+        )[0]
+
+        boxes = results["boxes"].cpu().numpy()
+        scores = results["scores"].cpu().numpy()
+        labels = results["labels"]
+
+        class_ids = np.array(
+            [self._label_to_class_id(label, prompts) for label in labels]
+        )
+
+        return sv.Detections(
+            xyxy=boxes,
+            confidence=scores,
+            class_id=class_ids if len(class_ids) > 0 else np.array([], dtype=int),
+            data={"class_name": np.array(labels) if labels else np.array([])},
+        )
+
+    @staticmethod
+    def _label_to_class_id(label: str, prompts: list[str]) -> int:
+        """Map a detection label back to a prompt index."""
+        label_lower = label.lower().strip()
+        for i, prompt in enumerate(prompts):
+            if prompt.lower() in label_lower or label_lower in prompt.lower():
+                return i
+        return 0

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -1,0 +1,153 @@
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import supervision as sv
+
+from dino.detectors.base import BaseDetector
+from dino.detectors.grounding_dino import GroundingDINODetector
+
+
+def _make_mock_inputs():
+    """Create a MagicMock that behaves like processor output (supports .to() and dict access)."""
+    inputs = MagicMock()
+    inputs.__getitem__ = MagicMock(side_effect=lambda k: MagicMock())
+    inputs.to.return_value = inputs
+    return inputs
+
+
+def _setup_mocks(mock_model_cls, mock_proc_cls, boxes, scores, labels):
+    """Set up processor and model mocks with given detection results."""
+    mock_processor = MagicMock()
+    mock_proc_cls.from_pretrained.return_value = mock_processor
+    mock_processor.return_value = _make_mock_inputs()
+
+    mock_model = MagicMock()
+    mock_model_cls.from_pretrained.return_value = mock_model
+    mock_model.to.return_value = mock_model
+    mock_model.device = "cpu"
+
+    mock_processor.post_process_grounded_object_detection.return_value = [
+        {
+            "boxes": MagicMock(
+                cpu=MagicMock(
+                    return_value=MagicMock(
+                        numpy=MagicMock(return_value=boxes)
+                    )
+                )
+            ),
+            "scores": MagicMock(
+                cpu=MagicMock(
+                    return_value=MagicMock(
+                        numpy=MagicMock(return_value=scores)
+                    )
+                )
+            ),
+            "labels": labels,
+        }
+    ]
+    return mock_processor, mock_model
+
+
+class TestBaseDetector:
+    def test_cannot_instantiate_directly(self):
+        with pytest.raises(TypeError):
+            BaseDetector()
+
+    def test_subclass_must_implement_detect(self):
+        class BadDetector(BaseDetector):
+            pass
+
+        with pytest.raises(TypeError):
+            BadDetector()
+
+
+class TestGroundingDINODetector:
+    @patch("dino.detectors.grounding_dino.AutoProcessor")
+    @patch("dino.detectors.grounding_dino.AutoModelForZeroShotObjectDetection")
+    def test_detect_returns_sv_detections(self, mock_model_cls, mock_proc_cls):
+        _setup_mocks(
+            mock_model_cls,
+            mock_proc_cls,
+            boxes=np.array([[10.0, 20.0, 100.0, 200.0]], dtype=np.float32),
+            scores=np.array([0.85], dtype=np.float32),
+            labels=["person"],
+        )
+
+        detector = GroundingDINODetector(device="cpu")
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        detections = detector.detect(frame, ["person"])
+
+        assert isinstance(detections, sv.Detections)
+        assert len(detections) == 1
+        assert detections.xyxy.shape == (1, 4)
+
+    @patch("dino.detectors.grounding_dino.AutoProcessor")
+    @patch("dino.detectors.grounding_dino.AutoModelForZeroShotObjectDetection")
+    def test_detect_empty_results(self, mock_model_cls, mock_proc_cls):
+        _setup_mocks(
+            mock_model_cls,
+            mock_proc_cls,
+            boxes=np.empty((0, 4), dtype=np.float32),
+            scores=np.array([], dtype=np.float32),
+            labels=[],
+        )
+
+        detector = GroundingDINODetector(device="cpu")
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        detections = detector.detect(frame, ["unicorn"])
+
+        assert isinstance(detections, sv.Detections)
+        assert len(detections) == 0
+
+    @patch("dino.detectors.grounding_dino.AutoProcessor")
+    @patch("dino.detectors.grounding_dino.AutoModelForZeroShotObjectDetection")
+    def test_prompts_joined_with_period(self, mock_model_cls, mock_proc_cls):
+        mock_processor, _ = _setup_mocks(
+            mock_model_cls,
+            mock_proc_cls,
+            boxes=np.empty((0, 4), dtype=np.float32),
+            scores=np.array([], dtype=np.float32),
+            labels=[],
+        )
+
+        detector = GroundingDINODetector(device="cpu")
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        detector.detect(frame, ["person", "table", "plate"])
+
+        # Verify processor was called with period-separated prompts
+        call_args = mock_processor.call_args
+        text_arg = call_args[1]["text"]
+        assert text_arg == "person. table. plate."
+
+    @patch("dino.detectors.grounding_dino.AutoProcessor")
+    @patch("dino.detectors.grounding_dino.AutoModelForZeroShotObjectDetection")
+    def test_is_base_detector_subclass(self, mock_model_cls, mock_proc_cls):
+        mock_proc_cls.from_pretrained.return_value = MagicMock()
+        mock_model = MagicMock()
+        mock_model.to.return_value = mock_model
+        mock_model_cls.from_pretrained.return_value = mock_model
+
+        detector = GroundingDINODetector(device="cpu")
+        assert isinstance(detector, BaseDetector)
+
+    @patch("dino.detectors.grounding_dino.AutoProcessor")
+    @patch("dino.detectors.grounding_dino.AutoModelForZeroShotObjectDetection")
+    def test_multiple_detections(self, mock_model_cls, mock_proc_cls):
+        _setup_mocks(
+            mock_model_cls,
+            mock_proc_cls,
+            boxes=np.array(
+                [[10, 20, 100, 200], [300, 400, 500, 600]], dtype=np.float32
+            ),
+            scores=np.array([0.9, 0.7], dtype=np.float32),
+            labels=["person", "table"],
+        )
+
+        detector = GroundingDINODetector(device="cpu")
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        detections = detector.detect(frame, ["person", "table"])
+
+        assert len(detections) == 2
+        assert detections.confidence[0] == pytest.approx(0.9)
+        assert detections.confidence[1] == pytest.approx(0.7)


### PR DESCRIPTION
## Summary
- Implement `BaseDetector` ABC with `detect(frame, prompts) -> sv.Detections`
- Implement `GroundingDINODetector` wrapper using HF Transformers
  - Auto-detects device (CUDA > MPS > CPU)
  - Period-separated text prompt formatting
  - Returns `sv.Detections` with boxes, scores, class_id, and class_name data
- Add demo script `scripts/demo_grounding_dino.py`
- 7 unit tests with mocked models (no GPU required)

## Test plan
- [x] `uv run pytest tests/test_detectors.py -v` — 7/7 passing

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)