### PR TITLE
Add ByteTrack tracking, annotation, and frame processor

### DIFF
--- a/src/dino/annotation/annotator.py
+++ b/src/dino/annotation/annotator.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import numpy as np
+import supervision as sv
+
+
+class FrameAnnotator:
+    """Annotate frames with bounding boxes, labels, and tracking traces."""
+
+    def __init__(self, trace_length: int = 60):
+        self._box_annotator = sv.BoxAnnotator()
+        self._label_annotator = sv.LabelAnnotator()
+        self._trace_annotator = sv.TraceAnnotator(
+            position=sv.Position.BOTTOM_CENTER,
+            trace_length=trace_length,
+        )
+
+    def annotate(
+        self,
+        frame: np.ndarray,
+        detections: sv.Detections,
+        labels: list[str] | None = None,
+    ) -> np.ndarray:
+        """Draw boxes, labels, and traces on a frame."""
+        annotated = frame.copy()
+
+        if labels is None:
+            labels = self._build_labels(detections)
+
+        annotated = self._box_annotator.annotate(
+            scene=annotated, detections=detections
+        )
+        annotated = self._label_annotator.annotate(
+            scene=annotated, detections=detections, labels=labels
+        )
+
+        if detections.tracker_id is not None:
+            annotated = self._trace_annotator.annotate(
+                scene=annotated, detections=detections
+            )
+
+        return annotated
+
+    @staticmethod
+    def _build_labels(detections: sv.Detections) -> list[str]:
+        """Build default labels from detection data."""
+        labels = []
+        for i in range(len(detections)):
+            parts = []
+            if "class_name" in detections.data and len(detections.data["class_name"]) > i:
+                parts.append(str(detections.data["class_name"][i]))
+            if detections.tracker_id is not None:
+                parts.append(f"#{detections.tracker_id[i]}")
+            if detections.confidence is not None:
+                parts.append(f"{detections.confidence[i]:.2f}")
+            labels.append(" ".join(parts))
+        return labels

--- a/src/dino/pipeline/frame_processor.py
+++ b/src/dino/pipeline/frame_processor.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import numpy as np
+import supervision as sv
+
+from dino.detectors.base import BaseDetector
+from dino.tracking.tracker import ObjectTracker
+
+
+class FrameProcessor:
+    """Process a single frame: detect objects and update tracking."""
+
+    def __init__(self, detector: BaseDetector, tracker: ObjectTracker | None = None):
+        self.detector = detector
+        self.tracker = tracker or ObjectTracker()
+
+    def process(
+        self, frame: np.ndarray, prompts: list[str]
+    ) -> sv.Detections:
+        """Detect objects and assign tracking IDs."""
+        detections = self.detector.detect(frame, prompts)
+        detections = self.tracker.update(detections)
+        return detections

--- a/src/dino/tracking/tracker.py
+++ b/src/dino/tracking/tracker.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import supervision as sv
+
+
+class ObjectTracker:
+    """ByteTrack object tracker wrapper."""
+
+    def __init__(
+        self,
+        track_activation_threshold: float = 0.25,
+        lost_track_buffer: int = 30,
+        minimum_matching_threshold: float = 0.8,
+        frame_rate: int = 30,
+    ):
+        self._tracker = sv.ByteTrack(
+            track_activation_threshold=track_activation_threshold,
+            lost_track_buffer=lost_track_buffer,
+            minimum_matching_threshold=minimum_matching_threshold,
+            frame_rate=frame_rate,
+        )
+
+    def update(self, detections: sv.Detections) -> sv.Detections:
+        """Update tracker with new detections, returns detections with tracker_id."""
+        return self._tracker.update_with_detections(detections)
+
+    def reset(self) -> None:
+        """Reset tracker state."""
+        self._tracker.reset()

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,0 +1,71 @@
+import numpy as np
+import supervision as sv
+
+from dino.tracking.tracker import ObjectTracker
+
+
+class TestObjectTracker:
+    def test_returns_detections_with_tracker_id(self):
+        tracker = ObjectTracker()
+        detections = sv.Detections(
+            xyxy=np.array([[10, 20, 100, 200]], dtype=np.float32),
+            confidence=np.array([0.9]),
+            class_id=np.array([0]),
+        )
+        tracked = tracker.update(detections)
+        assert isinstance(tracked, sv.Detections)
+        assert tracked.tracker_id is not None
+        assert len(tracked.tracker_id) == 1
+
+    def test_consistent_ids_across_frames(self):
+        tracker = ObjectTracker()
+
+        det1 = sv.Detections(
+            xyxy=np.array([[10, 20, 100, 200]], dtype=np.float32),
+            confidence=np.array([0.9]),
+            class_id=np.array([0]),
+        )
+        tracked1 = tracker.update(det1)
+
+        # Slightly moved box — same object
+        det2 = sv.Detections(
+            xyxy=np.array([[12, 22, 102, 202]], dtype=np.float32),
+            confidence=np.array([0.9]),
+            class_id=np.array([0]),
+        )
+        tracked2 = tracker.update(det2)
+
+        assert tracked1.tracker_id[0] == tracked2.tracker_id[0]
+
+    def test_empty_detections(self):
+        tracker = ObjectTracker()
+        detections = sv.Detections.empty()
+        tracked = tracker.update(detections)
+        assert isinstance(tracked, sv.Detections)
+        assert len(tracked) == 0
+
+    def test_multiple_objects_get_different_ids(self):
+        tracker = ObjectTracker()
+        detections = sv.Detections(
+            xyxy=np.array(
+                [[10, 20, 100, 200], [300, 400, 500, 600]], dtype=np.float32
+            ),
+            confidence=np.array([0.9, 0.8]),
+            class_id=np.array([0, 1]),
+        )
+        tracked = tracker.update(detections)
+        assert len(tracked.tracker_id) == 2
+        assert tracked.tracker_id[0] != tracked.tracker_id[1]
+
+    def test_reset_clears_state(self):
+        tracker = ObjectTracker()
+        detections = sv.Detections(
+            xyxy=np.array([[10, 20, 100, 200]], dtype=np.float32),
+            confidence=np.array([0.9]),
+            class_id=np.array([0]),
+        )
+        tracker.update(detections)
+        tracker.reset()
+        # After reset, tracker state should be clean
+        tracked = tracker.update(detections)
+        assert tracked.tracker_id is not None


### PR DESCRIPTION
## Summary
- `ObjectTracker`: ByteTrack wrapper with configurable parameters and reset support
- `FrameAnnotator`: Bounding box, label, and trace drawing via supervision
- `FrameProcessor`: Composes detector + tracker for single-frame processing
- 5 unit tests for tracker (ID assignment, consistency, multi-object, reset)

## Test plan
- [x] `uv run pytest tests/test_tracker.py -v` — 5/5 passing

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)