### PR TITLE
Add table state FSM for restaurant operations

### DIFF
--- a/src/dino/state/table_state.py
+++ b/src/dino/state/table_state.py
@@ -1,0 +1,59 @@
+from enum import Enum
+
+
+class TableState(Enum):
+    EMPTY = "empty"
+    OCCUPIED = "occupied"
+    SERVED = "served"
+    CLEARING = "clearing"
+
+
+VALID_TRANSITIONS: dict[TableState, set[TableState]] = {
+    TableState.EMPTY: {TableState.OCCUPIED},
+    TableState.OCCUPIED: {TableState.SERVED, TableState.EMPTY},
+    TableState.SERVED: {TableState.CLEARING},
+    TableState.CLEARING: {TableState.EMPTY},
+}
+
+
+class TableStateMachine:
+    def __init__(self, table_id: str, hysteresis: int = 3):
+        self.table_id = table_id
+        self._state = TableState.EMPTY
+        self._hysteresis = hysteresis
+        self._pending_state: TableState | None = None
+        self._pending_count: int = 0
+        self._history: list[dict] = [{"state": TableState.EMPTY, "frame_number": 0}]
+
+    @property
+    def state(self) -> TableState:
+        return self._state
+
+    @property
+    def history(self) -> list[dict]:
+        return list(self._history)
+
+    def update(self, observed_state: TableState, frame_number: int = 0) -> TableState:
+        if observed_state == self._state:
+            self._pending_state = None
+            self._pending_count = 0
+            return self._state
+
+        if observed_state not in VALID_TRANSITIONS.get(self._state, set()):
+            self._pending_state = None
+            self._pending_count = 0
+            return self._state
+
+        if observed_state == self._pending_state:
+            self._pending_count += 1
+        else:
+            self._pending_state = observed_state
+            self._pending_count = 1
+
+        if self._pending_count >= self._hysteresis:
+            self._state = observed_state
+            self._history.append({"state": observed_state, "frame_number": frame_number})
+            self._pending_state = None
+            self._pending_count = 0
+
+        return self._state

--- a/tests/test_table_state.py
+++ b/tests/test_table_state.py
@@ -1,0 +1,100 @@
+import pytest
+from dino.state.table_state import TableState, TableStateMachine
+
+
+class TestTableState:
+    def test_states_exist(self):
+        assert TableState.EMPTY is not None
+        assert TableState.OCCUPIED is not None
+        assert TableState.SERVED is not None
+        assert TableState.CLEARING is not None
+
+
+class TestTableStateMachine:
+    def test_initial_state_is_empty(self):
+        fsm = TableStateMachine(table_id="T1")
+        assert fsm.state == TableState.EMPTY
+
+    def test_valid_transition_empty_to_occupied(self):
+        fsm = TableStateMachine(table_id="T1", hysteresis=1)
+        fsm.update(TableState.OCCUPIED)
+        assert fsm.state == TableState.OCCUPIED
+
+    def test_valid_transition_occupied_to_served(self):
+        fsm = TableStateMachine(table_id="T1", hysteresis=1)
+        fsm.update(TableState.OCCUPIED)
+        fsm.update(TableState.SERVED)
+        assert fsm.state == TableState.SERVED
+
+    def test_valid_transition_served_to_clearing(self):
+        fsm = TableStateMachine(table_id="T1", hysteresis=1)
+        fsm.update(TableState.OCCUPIED)
+        fsm.update(TableState.SERVED)
+        fsm.update(TableState.CLEARING)
+        assert fsm.state == TableState.CLEARING
+
+    def test_valid_transition_clearing_to_empty(self):
+        fsm = TableStateMachine(table_id="T1", hysteresis=1)
+        fsm.update(TableState.OCCUPIED)
+        fsm.update(TableState.SERVED)
+        fsm.update(TableState.CLEARING)
+        fsm.update(TableState.EMPTY)
+        assert fsm.state == TableState.EMPTY
+
+    def test_invalid_transition_empty_to_served(self):
+        fsm = TableStateMachine(table_id="T1", hysteresis=1)
+        fsm.update(TableState.SERVED)
+        assert fsm.state == TableState.EMPTY
+
+    def test_invalid_transition_empty_to_clearing(self):
+        fsm = TableStateMachine(table_id="T1", hysteresis=1)
+        fsm.update(TableState.CLEARING)
+        assert fsm.state == TableState.EMPTY
+
+    def test_hysteresis_requires_consecutive_frames(self):
+        fsm = TableStateMachine(table_id="T1", hysteresis=3)
+        fsm.update(TableState.OCCUPIED)
+        assert fsm.state == TableState.EMPTY
+        fsm.update(TableState.OCCUPIED)
+        assert fsm.state == TableState.EMPTY
+        fsm.update(TableState.OCCUPIED)
+        assert fsm.state == TableState.OCCUPIED
+
+    def test_hysteresis_resets_on_different_state(self):
+        fsm = TableStateMachine(table_id="T1", hysteresis=3)
+        fsm.update(TableState.OCCUPIED)
+        fsm.update(TableState.OCCUPIED)
+        fsm.update(TableState.EMPTY)  # resets counter
+        fsm.update(TableState.OCCUPIED)
+        assert fsm.state == TableState.EMPTY
+
+    def test_history_recording(self):
+        fsm = TableStateMachine(table_id="T1", hysteresis=1)
+        fsm.update(TableState.OCCUPIED)
+        fsm.update(TableState.SERVED)
+        history = fsm.history
+        assert len(history) == 3
+        assert history[0]["state"] == TableState.EMPTY
+        assert history[1]["state"] == TableState.OCCUPIED
+        assert history[2]["state"] == TableState.SERVED
+
+    def test_history_has_frame_numbers(self):
+        fsm = TableStateMachine(table_id="T1", hysteresis=1)
+        fsm.update(TableState.OCCUPIED, frame_number=10)
+        history = fsm.history
+        assert history[1]["frame_number"] == 10
+
+    def test_table_id(self):
+        fsm = TableStateMachine(table_id="T42")
+        assert fsm.table_id == "T42"
+
+    def test_same_state_update_does_not_add_history(self):
+        fsm = TableStateMachine(table_id="T1", hysteresis=1)
+        fsm.update(TableState.EMPTY)
+        assert len(fsm.history) == 1
+
+    def test_occupied_can_go_back_to_empty(self):
+        fsm = TableStateMachine(table_id="T1", hysteresis=1)
+        fsm.update(TableState.OCCUPIED)
+        fsm.update(TableState.EMPTY)
+        assert fsm.state == TableState.EMPTY


### PR DESCRIPTION
## Summary
- `TableState` enum: EMPTY, OCCUPIED, SERVED, CLEARING
- `TableStateMachine` with:
  - Valid transition enforcement (directed graph)
  - Configurable hysteresis (N consecutive frames required)
  - State history recording with frame numbers
- 15 unit tests: transitions, invalid states, hysteresis, history

## Test plan
- [x] `uv run pytest tests/test_table_state.py -v` — 15/15 passing

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)