### PR TITLE
Add end-to-end video pipeline with config and CLI

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""CLI entry point for the video processing pipeline."""
+
+import argparse
+import sys
+from pathlib import Path
+
+from dino.config import PipelineConfig
+from dino.detectors.grounding_dino import GroundingDINODetector
+from dino.pipeline.video_pipeline import VideoPipeline
+
+TABLE_PROMPTS = ["empty table", "person sitting at table", "plate of food on table", "dirty plate"]
+SERVICE_PROMPTS = ["person raising hand", "server carrying food", "empty glass", "menu on table"]
+STAFF_PROMPTS = ["person in uniform", "server", "chef"]
+
+PROMPT_PRESETS = {
+    "table": TABLE_PROMPTS,
+    "service": SERVICE_PROMPTS,
+    "staff": STAFF_PROMPTS,
+    "all": TABLE_PROMPTS + SERVICE_PROMPTS + STAFF_PROMPTS,
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="DINO Restaurant Visual Pipeline")
+    parser.add_argument("--input", required=True, help="Input video path")
+    parser.add_argument("--output", required=True, help="Output video path")
+    parser.add_argument("--json", default=None, help="Path to export JSON results")
+    parser.add_argument(
+        "--prompts",
+        nargs="+",
+        default=None,
+        help="Custom text prompts for detection",
+    )
+    parser.add_argument(
+        "--preset",
+        choices=list(PROMPT_PRESETS.keys()),
+        default="all",
+        help="Prompt preset (default: all)",
+    )
+    parser.add_argument("--stride", type=int, default=1, help="Process every Nth frame")
+    parser.add_argument("--threshold", type=float, default=0.3, help="Box confidence threshold")
+    parser.add_argument("--device", default=None, help="Device (cuda/mps/cpu)")
+    args = parser.parse_args()
+
+    if not Path(args.input).exists():
+        print(f"Error: input video not found: {args.input}", file=sys.stderr)
+        sys.exit(1)
+
+    prompts = args.prompts or PROMPT_PRESETS[args.preset]
+    print(f"Prompts: {prompts}")
+
+    config = PipelineConfig(
+        prompts=prompts,
+        box_threshold=args.threshold,
+        stride=args.stride,
+    )
+
+    print("Loading Grounding DINO...")
+    detector = GroundingDINODetector(
+        box_threshold=args.threshold,
+        device=args.device,
+    )
+    print(f"Device: {detector.device}")
+
+    pipeline = VideoPipeline(detector=detector, config=config)
+
+    json_path = args.json
+    if json_path is None:
+        json_path = str(Path(args.output).with_suffix(".json"))
+
+    print(f"Processing: {args.input}")
+    print(f"Output video: {args.output}")
+    print(f"Output JSON: {json_path}")
+    print(f"Stride: {args.stride}")
+
+    results = pipeline.run(args.input, args.output, json_output=json_path)
+
+    total_detections = sum(len(r["detections"]) for r in results)
+    print(f"\nDone! Processed {len(results)} frames, {total_detections} total detections.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dino/config.py
+++ b/src/dino/config.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class PipelineConfig:
+    """Configuration for the video processing pipeline."""
+
+    prompts: list[str] = field(default_factory=list)
+    box_threshold: float = 0.3
+    text_threshold: float = 0.25
+    stride: int = 1
+    track_activation_threshold: float = 0.25
+    lost_track_buffer: int = 30
+    trace_length: int = 60

--- a/src/dino/pipeline/video_pipeline.py
+++ b/src/dino/pipeline/video_pipeline.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import cv2
+import numpy as np
+import supervision as sv
+
+from dino.annotation.annotator import FrameAnnotator
+from dino.config import PipelineConfig
+from dino.detectors.base import BaseDetector
+from dino.tracking.tracker import ObjectTracker
+
+
+class VideoPipeline:
+    """End-to-end video processing: detect, track, annotate, export."""
+
+    def __init__(self, detector: BaseDetector, config: PipelineConfig):
+        self.detector = detector
+        self.config = config
+        self.tracker = ObjectTracker(
+            track_activation_threshold=config.track_activation_threshold,
+            lost_track_buffer=config.lost_track_buffer,
+        )
+        self.annotator = FrameAnnotator(trace_length=config.trace_length)
+
+    def run(
+        self,
+        input_path: str,
+        output_path: str,
+        json_output: str | None = None,
+    ) -> list[dict]:
+        """Process a video file end-to-end.
+
+        Args:
+            input_path: Path to input video.
+            output_path: Path for annotated output video.
+            json_output: Optional path to export per-frame results as JSON.
+
+        Returns:
+            List of per-frame result dicts.
+        """
+        video_info = sv.VideoInfo.from_video_path(input_path)
+        frame_generator = sv.get_video_frames_generator(input_path)
+
+        results: list[dict] = []
+
+        with sv.VideoSink(output_path, video_info) as sink:
+            for frame_idx, frame in enumerate(frame_generator):
+                if frame_idx % self.config.stride != 0:
+                    continue
+
+                detections = self.detector.detect(frame, self.config.prompts)
+                detections = self.tracker.update(detections)
+
+                annotated = self.annotator.annotate(frame, detections)
+                sink.write_frame(annotated)
+
+                frame_result = self._detections_to_dict(frame_idx, detections)
+                results.append(frame_result)
+
+        if json_output:
+            Path(json_output).parent.mkdir(parents=True, exist_ok=True)
+            with open(json_output, "w") as f:
+                json.dump(results, f, indent=2)
+
+        return results
+
+    @staticmethod
+    def _detections_to_dict(frame_idx: int, detections: sv.Detections) -> dict:
+        """Convert frame detections to a serializable dict."""
+        det_list = []
+        for i in range(len(detections)):
+            det = {
+                "bbox": detections.xyxy[i].tolist(),
+            }
+            if detections.confidence is not None:
+                det["confidence"] = float(detections.confidence[i])
+            if detections.class_id is not None and len(detections.class_id) > i:
+                det["class_id"] = int(detections.class_id[i])
+            if detections.tracker_id is not None and len(detections.tracker_id) > i:
+                det["tracker_id"] = int(detections.tracker_id[i])
+            if "class_name" in detections.data and len(detections.data["class_name"]) > i:
+                det["class_name"] = str(detections.data["class_name"][i])
+            det_list.append(det)
+
+        return {"frame": frame_idx, "detections": det_list}

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,119 @@
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import cv2
+import numpy as np
+import pytest
+import supervision as sv
+
+from dino.config import PipelineConfig
+from dino.pipeline.video_pipeline import VideoPipeline
+
+
+def _make_test_video(path: str, num_frames: int = 10, fps: int = 30):
+    """Create a small test video."""
+    h, w = 240, 320
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(path, fourcc, fps, (w, h))
+    for i in range(num_frames):
+        frame = np.zeros((h, w, 3), dtype=np.uint8)
+        frame[:] = (i * 25, i * 10, 0)  # varying colors
+        writer.write(frame)
+    writer.release()
+
+
+class TestPipelineConfig:
+    def test_default_values(self):
+        config = PipelineConfig()
+        assert config.prompts == []
+        assert config.box_threshold == 0.3
+        assert config.stride == 1
+
+    def test_custom_values(self):
+        config = PipelineConfig(
+            prompts=["person", "table"],
+            box_threshold=0.5,
+            stride=3,
+        )
+        assert config.prompts == ["person", "table"]
+        assert config.box_threshold == 0.5
+        assert config.stride == 3
+
+
+class TestVideoPipeline:
+    def test_process_video_creates_output(self, tmp_path):
+        # Create test video
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        _make_test_video(input_path, num_frames=5)
+
+        # Mock detector that returns empty detections
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = sv.Detections.empty()
+
+        config = PipelineConfig(prompts=["person"], stride=1)
+        pipeline = VideoPipeline(detector=mock_detector, config=config)
+        pipeline.run(input_path, output_path)
+
+        assert Path(output_path).exists()
+        assert mock_detector.detect.call_count == 5
+
+    def test_stride_skips_frames(self, tmp_path):
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        _make_test_video(input_path, num_frames=10)
+
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = sv.Detections.empty()
+
+        config = PipelineConfig(prompts=["person"], stride=3)
+        pipeline = VideoPipeline(detector=mock_detector, config=config)
+        pipeline.run(input_path, output_path)
+
+        # With stride=3 on 10 frames: process frames 0, 3, 6, 9 = 4 frames
+        assert mock_detector.detect.call_count == 4
+
+    def test_json_results_exported(self, tmp_path):
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        json_path = str(tmp_path / "results.json")
+        _make_test_video(input_path, num_frames=3)
+
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = sv.Detections(
+            xyxy=np.array([[10, 20, 100, 200]], dtype=np.float32),
+            confidence=np.array([0.9]),
+            class_id=np.array([0]),
+        )
+
+        config = PipelineConfig(prompts=["person"], stride=1)
+        pipeline = VideoPipeline(detector=mock_detector, config=config)
+        pipeline.run(input_path, output_path, json_output=json_path)
+
+        assert Path(json_path).exists()
+        with open(json_path) as f:
+            results = json.load(f)
+        assert len(results) == 3
+        assert "frame" in results[0]
+        assert "detections" in results[0]
+
+    def test_with_detections(self, tmp_path):
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        _make_test_video(input_path, num_frames=3)
+
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = sv.Detections(
+            xyxy=np.array([[10, 20, 100, 200]], dtype=np.float32),
+            confidence=np.array([0.9]),
+            class_id=np.array([0]),
+            data={"class_name": np.array(["person"])},
+        )
+
+        config = PipelineConfig(prompts=["person"], stride=1)
+        pipeline = VideoPipeline(detector=mock_detector, config=config)
+        pipeline.run(input_path, output_path)
+
+        assert Path(output_path).exists()


### PR DESCRIPTION
## Summary
- `PipelineConfig` dataclass for all pipeline settings
- `VideoPipeline`: full video processing — frame iteration with stride, detect + track + annotate, VideoSink output, JSON export
- `scripts/run_pipeline.py` CLI with restaurant-specific prompt presets (table, service, staff, all)
- 6 integration tests with mocked detector

## Test plan
- [x] `uv run pytest tests/ -v` — 33/33 tests passing across all modules

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)