### PR TITLE
Add full showcase demo with enhanced annotations and HTML report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "Pillow",
     "numpy",
     "accelerate",
+    "tqdm",
 ]
 
 [project.optional-dependencies]

--- a/scripts/demo_showcase.py
+++ b/scripts/demo_showcase.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""CLI entry point for the full DINO showcase demo."""
+
+import argparse
+import sys
+from pathlib import Path
+
+from tqdm import tqdm
+
+from dino.annotation.showcase_annotator import ShowcaseAnnotator
+from dino.config import PipelineConfig
+from dino.detectors.grounding_dino import GroundingDINODetector
+from dino.pipeline.video_pipeline import VideoPipeline
+from dino.showcase.reporter import ShowcaseReporter, ShowcaseStats, extract_sample_frames
+
+TABLE_PROMPTS = ["empty table", "person sitting at table", "plate of food on table", "dirty plate"]
+SERVICE_PROMPTS = ["person raising hand", "server carrying food", "empty glass", "menu on table"]
+STAFF_PROMPTS = ["person in uniform", "server", "chef"]
+
+PROMPT_PRESETS = {
+    "table": TABLE_PROMPTS,
+    "service": SERVICE_PROMPTS,
+    "staff": STAFF_PROMPTS,
+    "all": TABLE_PROMPTS + SERVICE_PROMPTS + STAFF_PROMPTS,
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="DINO Full Showcase Demo")
+    parser.add_argument("--input", required=True, help="Input video path")
+    parser.add_argument("--output-dir", required=True, help="Output directory")
+    parser.add_argument(
+        "--prompts", nargs="+", default=None, help="Custom text prompts"
+    )
+    parser.add_argument(
+        "--preset",
+        choices=list(PROMPT_PRESETS.keys()),
+        default="all",
+        help="Prompt preset (default: all)",
+    )
+    parser.add_argument("--stride", type=int, default=1, help="Process every Nth frame")
+    parser.add_argument("--threshold", type=float, default=0.3, help="Box confidence threshold")
+    parser.add_argument("--device", default=None, help="Device (cuda/mps/cpu)")
+    args = parser.parse_args()
+
+    try:
+        input_path = Path(args.input)
+        if not input_path.exists():
+            print(f"Error: input video not found: {args.input}", file=sys.stderr)
+            sys.exit(1)
+
+        output_dir = Path(args.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        prompts = args.prompts or PROMPT_PRESETS[args.preset]
+        print(f"Prompts: {prompts}")
+
+        config = PipelineConfig(
+            prompts=prompts,
+            box_threshold=args.threshold,
+            stride=args.stride,
+        )
+
+        print("Loading Grounding DINO...")
+        detector = GroundingDINODetector(
+            box_threshold=args.threshold,
+            device=args.device,
+        )
+        print(f"Device: {detector.device}")
+
+        pipeline = VideoPipeline(detector=detector, config=config)
+        pipeline.annotator = ShowcaseAnnotator(
+            prompts=prompts,
+            trace_length=config.trace_length,
+        )
+
+        annotated_path = str(output_dir / "annotated.mp4")
+        sbs_path = str(output_dir / "side_by_side.mp4")
+        json_path = str(output_dir / "results.json")
+
+        print(f"Processing: {args.input}")
+        print(f"Output dir: {output_dir}")
+
+        progress_bar = tqdm(desc="Processing frames", unit="frame")
+
+        def on_progress(processed: int, total: int) -> None:
+            progress_bar.total = total
+            progress_bar.n = processed
+            progress_bar.refresh()
+
+        results = pipeline.run(
+            input_path=str(input_path),
+            output_path=annotated_path,
+            json_output=json_path,
+            progress_callback=on_progress,
+            sbs_output=sbs_path,
+        )
+        progress_bar.close()
+
+        print("\nExtracting sample frames...")
+        sample_frames = extract_sample_frames(annotated_path, count=8)
+
+        import supervision as sv
+        video_info = sv.VideoInfo.from_video_path(str(input_path))
+        effective_fps = video_info.fps / config.stride if config.stride > 1 else video_info.fps
+
+        print("Generating HTML report...")
+        stats = ShowcaseStats.from_results(results, fps=effective_fps)
+        report_path = ShowcaseReporter.generate(stats, sample_frames, str(output_dir))
+
+        print(f"\nDone! Processed {stats.total_frames} frames, {stats.total_detections} detections.")
+        print(f"  Annotated video: {annotated_path}")
+        print(f"  Side-by-side:    {sbs_path}")
+        print(f"  JSON results:    {json_path}")
+        print(f"  HTML report:     {report_path}")
+
+    except KeyboardInterrupt:
+        print("\nInterrupted.", file=sys.stderr)
+        sys.exit(130)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dino/annotation/showcase_annotator.py
+++ b/src/dino/annotation/showcase_annotator.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from collections import Counter
+
+import cv2
+import numpy as np
+import supervision as sv
+
+from dino.annotation.annotator import FrameAnnotator
+
+
+class ShowcaseAnnotator(FrameAnnotator):
+    """Enhanced annotator with per-class colors and a HUD overlay."""
+
+    def __init__(self, prompts: list[str], trace_length: int = 60):
+        super().__init__(trace_length=trace_length)
+        self.prompts = prompts
+        self._box_annotator = sv.BoxAnnotator(
+            color_lookup=sv.ColorLookup.CLASS,
+        )
+        self._label_annotator = sv.LabelAnnotator(
+            color_lookup=sv.ColorLookup.CLASS,
+        )
+        self._trace_annotator = sv.TraceAnnotator(
+            position=sv.Position.BOTTOM_CENTER,
+            trace_length=trace_length,
+            color_lookup=sv.ColorLookup.CLASS,
+        )
+
+    def annotate(
+        self,
+        frame: np.ndarray,
+        detections: sv.Detections,
+        labels: list[str] | None = None,
+    ) -> np.ndarray:
+        annotated = super().annotate(frame, detections, labels)
+        annotated = self._draw_hud(annotated, detections)
+        return annotated
+
+    def _draw_hud(self, frame: np.ndarray, detections: sv.Detections) -> np.ndarray:
+        """Draw a semi-transparent HUD bar at the top of the frame."""
+        _, w = frame.shape[:2]
+        bar_height = 40
+        overlay = frame.copy()
+        cv2.rectangle(overlay, (0, 0), (w, bar_height), (0, 0, 0), -1)
+        frame = cv2.addWeighted(overlay, 0.6, frame, 0.4, 0)
+
+        total = len(detections)
+        class_counts: Counter[str] = Counter()
+        if "class_name" in detections.data:
+            for name in detections.data["class_name"]:
+                class_counts[str(name)] += 1
+
+        parts = [f"Detections: {total}"]
+        for name, count in class_counts.most_common():
+            parts.append(f"{name}:{count}")
+        text = "  ".join(parts)
+
+        cv2.putText(
+            frame,
+            text,
+            (10, 28),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.7,
+            (255, 255, 255),
+            2,
+        )
+        return frame

--- a/src/dino/pipeline/video_pipeline.py
+++ b/src/dino/pipeline/video_pipeline.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import contextlib
 import json
+from collections.abc import Callable
 from pathlib import Path
 
+import numpy as np
 import supervision as sv
 
 from dino.annotation.annotator import FrameAnnotator
@@ -28,6 +31,8 @@ class VideoPipeline:
         input_path: str,
         output_path: str,
         json_output: str | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
+        sbs_output: str | None = None,
     ) -> list[dict]:
         """Process a video file end-to-end.
 
@@ -35,6 +40,8 @@ class VideoPipeline:
             input_path: Path to input video.
             output_path: Path for annotated output video.
             json_output: Optional path to export per-frame results as JSON.
+            progress_callback: Optional callback(processed, total) called per frame.
+            sbs_output: Optional path for side-by-side (original|annotated) video.
 
         Returns:
             List of per-frame result dicts.
@@ -44,9 +51,26 @@ class VideoPipeline:
             video_info.fps = video_info.fps / self.config.stride
         frame_generator = sv.get_video_frames_generator(input_path)
 
-        results: list[dict] = []
+        total_frames = video_info.total_frames // self.config.stride
 
-        with sv.VideoSink(output_path, video_info) as sink:
+        sbs_info = None
+        if sbs_output:
+            sbs_info = sv.VideoInfo(
+                width=video_info.width * 2,
+                height=video_info.height,
+                fps=video_info.fps,
+                total_frames=video_info.total_frames,
+            )
+
+        results: list[dict] = []
+        processed = 0
+
+        with contextlib.ExitStack() as stack:
+            sink = stack.enter_context(sv.VideoSink(output_path, video_info))
+            sbs_sink = None
+            if sbs_output and sbs_info:
+                sbs_sink = stack.enter_context(sv.VideoSink(sbs_output, sbs_info))
+
             for frame_idx, frame in enumerate(frame_generator):
                 if frame_idx % self.config.stride != 0:
                     continue
@@ -57,8 +81,16 @@ class VideoPipeline:
                 annotated = self.annotator.annotate(frame, detections)
                 sink.write_frame(annotated)
 
+                if sbs_sink is not None:
+                    sbs_frame = np.hstack([frame, annotated])
+                    sbs_sink.write_frame(sbs_frame)
+
                 frame_result = self._detections_to_dict(frame_idx, detections)
                 results.append(frame_result)
+
+                processed += 1
+                if progress_callback is not None:
+                    progress_callback(processed, total_frames)
 
         if json_output:
             Path(json_output).parent.mkdir(parents=True, exist_ok=True)

--- a/src/dino/showcase/reporter.py
+++ b/src/dino/showcase/reporter.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import base64
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+
+@dataclass
+class ShowcaseStats:
+    """Aggregated statistics from pipeline results."""
+
+    total_frames: int = 0
+    video_duration_sec: float = 0.0
+    total_detections: int = 0
+    avg_detections_per_frame: float = 0.0
+    class_counts: dict[str, int] = field(default_factory=dict)
+    unique_tracker_ids: int = 0
+    peak_detection_count: int = 0
+    peak_detection_frame: int = 0
+    per_frame_counts: list[int] = field(default_factory=list)
+
+    @classmethod
+    def from_results(cls, results: list[dict], fps: float = 30.0) -> ShowcaseStats:
+        total_frames = len(results)
+        class_counter: Counter[str] = Counter()
+        tracker_ids: set[int] = set()
+        per_frame_counts: list[int] = []
+        peak_count = 0
+        peak_frame = 0
+
+        for entry in results:
+            dets = entry.get("detections", [])
+            count = len(dets)
+            per_frame_counts.append(count)
+            if count > peak_count:
+                peak_count = count
+                peak_frame = entry.get("frame", 0)
+            for det in dets:
+                if "class_name" in det:
+                    class_counter[det["class_name"]] += 1
+                if "tracker_id" in det:
+                    tracker_ids.add(det["tracker_id"])
+
+        total_detections = sum(per_frame_counts)
+        avg = total_detections / total_frames if total_frames > 0 else 0.0
+        duration = total_frames / fps if fps > 0 else 0.0
+
+        return cls(
+            total_frames=total_frames,
+            video_duration_sec=round(duration, 1),
+            total_detections=total_detections,
+            avg_detections_per_frame=round(avg, 1),
+            class_counts=dict(class_counter.most_common()),
+            unique_tracker_ids=len(tracker_ids),
+            peak_detection_count=peak_count,
+            peak_detection_frame=peak_frame,
+            per_frame_counts=per_frame_counts,
+        )
+
+
+def extract_sample_frames(video_path: str, count: int = 8) -> list[np.ndarray]:
+    """Read evenly-spaced frames from a video file."""
+    cap = cv2.VideoCapture(video_path)
+    total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    if total <= 0:
+        cap.release()
+        return []
+
+    indices = [int(i * total / count) for i in range(count)]
+    frames: list[np.ndarray] = []
+    for idx in indices:
+        cap.set(cv2.CAP_PROP_POS_FRAMES, idx)
+        ret, frame = cap.read()
+        if ret:
+            frames.append(frame)
+    cap.release()
+    return frames
+
+
+def _frame_to_base64(frame: np.ndarray, max_width: int = 640) -> str:
+    """Encode a frame as a base64 PNG string, resized if needed."""
+    h, w = frame.shape[:2]
+    if w > max_width:
+        scale = max_width / w
+        frame = cv2.resize(frame, (max_width, int(h * scale)))
+    _, buf = cv2.imencode(".png", frame)
+    return base64.b64encode(buf).decode("ascii")
+
+
+class ShowcaseReporter:
+    """Generate an HTML report from showcase stats and sample frames."""
+
+    @staticmethod
+    def generate(
+        stats: ShowcaseStats,
+        sample_frames: list[np.ndarray],
+        output_dir: str,
+    ) -> str:
+        output_path = Path(output_dir) / "report.html"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        frame_images = [_frame_to_base64(f) for f in sample_frames]
+        timeline_svg = _build_timeline_svg(stats.per_frame_counts)
+        class_rows = "\n".join(
+            f"<tr><td>{name}</td><td>{count}</td></tr>"
+            for name, count in stats.class_counts.items()
+        )
+        frame_gallery = "\n".join(
+            f'<img src="data:image/png;base64,{img}" style="max-width:320px;margin:4px;border-radius:4px;">'
+            for img in frame_images
+        )
+
+        html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>DINO Showcase Report</title>
+<style>
+  body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 0; padding: 20px; background: #0f172a; color: #e2e8f0; }}
+  h1 {{ color: #38bdf8; }}
+  h2 {{ color: #94a3b8; border-bottom: 1px solid #334155; padding-bottom: 8px; }}
+  .stats-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; margin: 20px 0; }}
+  .stat-card {{ background: #1e293b; border-radius: 8px; padding: 16px; text-align: center; }}
+  .stat-card .value {{ font-size: 2em; font-weight: bold; color: #38bdf8; }}
+  .stat-card .label {{ color: #94a3b8; font-size: 0.9em; margin-top: 4px; }}
+  table {{ border-collapse: collapse; width: 100%; max-width: 500px; }}
+  th, td {{ padding: 8px 16px; text-align: left; border-bottom: 1px solid #334155; }}
+  th {{ color: #94a3b8; }}
+  .gallery {{ display: flex; flex-wrap: wrap; gap: 8px; margin: 16px 0; }}
+  .gallery img {{ border: 1px solid #334155; }}
+  .timeline {{ margin: 20px 0; }}
+</style>
+</head>
+<body>
+<h1>DINO Showcase Report</h1>
+
+<div class="stats-grid">
+  <div class="stat-card"><div class="value">{stats.total_frames}</div><div class="label">Frames Processed</div></div>
+  <div class="stat-card"><div class="value">{stats.video_duration_sec}s</div><div class="label">Video Duration</div></div>
+  <div class="stat-card"><div class="value">{stats.total_detections}</div><div class="label">Total Detections</div></div>
+  <div class="stat-card"><div class="value">{stats.avg_detections_per_frame}</div><div class="label">Avg per Frame</div></div>
+  <div class="stat-card"><div class="value">{stats.unique_tracker_ids}</div><div class="label">Unique Tracks</div></div>
+  <div class="stat-card"><div class="value">{stats.peak_detection_count}</div><div class="label">Peak Detections (frame {stats.peak_detection_frame})</div></div>
+</div>
+
+<h2>Detection Timeline</h2>
+<div class="timeline">{timeline_svg}</div>
+
+<h2>Sample Frames</h2>
+<div class="gallery">
+{frame_gallery}
+</div>
+
+<h2>Class Breakdown</h2>
+<table>
+<tr><th>Class</th><th>Count</th></tr>
+{class_rows}
+</table>
+
+</body>
+</html>"""
+
+        output_path.write_text(html)
+        return str(output_path)
+
+
+def _build_timeline_svg(per_frame_counts: list[int]) -> str:
+    """Build an inline SVG bar chart of per-frame detection counts."""
+    if not per_frame_counts:
+        return "<p>No data</p>"
+
+    width = 800
+    height = 120
+    max_count = max(per_frame_counts) or 1
+    n = len(per_frame_counts)
+    bar_width = max(width / n, 1)
+
+    bars = []
+    for i, count in enumerate(per_frame_counts):
+        bar_height = (count / max_count) * (height - 10)
+        x = i * bar_width
+        y = height - bar_height
+        bars.append(
+            f'<rect x="{x:.1f}" y="{y:.1f}" width="{bar_width:.1f}" '
+            f'height="{bar_height:.1f}" fill="#38bdf8" opacity="0.8"/>'
+        )
+
+    rects = "\n".join(bars)
+    return (
+        f'<svg width="{width}" height="{height}" xmlns="http://www.w3.org/2000/svg"'
+        f' style="background:#1e293b;border-radius:8px;">\n{rects}\n</svg>'
+    )

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import os
+import tempfile
+
+import cv2
+import numpy as np
+
+from dino.showcase.reporter import (
+    ShowcaseReporter,
+    ShowcaseStats,
+    _build_timeline_svg,
+    extract_sample_frames,
+)
+
+
+def _make_sample_results(n_frames: int = 10) -> list[dict]:
+    results = []
+    for i in range(n_frames):
+        dets = []
+        for j in range(i % 4):
+            dets.append({
+                "bbox": [10, 10, 50, 50],
+                "confidence": 0.9,
+                "class_id": j % 2,
+                "tracker_id": j + 1,
+                "class_name": "person" if j % 2 == 0 else "table",
+            })
+        results.append({"frame": i, "detections": dets})
+    return results
+
+
+def _make_test_video(path: str, n_frames: int = 16, w: int = 320, h: int = 240) -> None:
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(path, fourcc, 30, (w, h))
+    for i in range(n_frames):
+        frame = np.full((h, w, 3), i * 15 % 256, dtype=np.uint8)
+        writer.write(frame)
+    writer.release()
+
+
+class TestShowcaseStats:
+    def test_from_results_basic(self):
+        results = _make_sample_results(10)
+        stats = ShowcaseStats.from_results(results, fps=10.0)
+        assert stats.total_frames == 10
+        assert stats.video_duration_sec == 1.0
+        assert stats.total_detections > 0
+        assert "person" in stats.class_counts
+        assert stats.unique_tracker_ids > 0
+        assert stats.peak_detection_count == 3
+        assert len(stats.per_frame_counts) == 10
+
+    def test_from_empty_results(self):
+        stats = ShowcaseStats.from_results([], fps=30.0)
+        assert stats.total_frames == 0
+        assert stats.total_detections == 0
+        assert stats.avg_detections_per_frame == 0.0
+
+    def test_avg_detections(self):
+        results = _make_sample_results(10)
+        stats = ShowcaseStats.from_results(results, fps=10.0)
+        expected_avg = round(stats.total_detections / 10, 1)
+        assert stats.avg_detections_per_frame == expected_avg
+
+
+class TestExtractSampleFrames:
+    def test_extracts_correct_count(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+            path = f.name
+        try:
+            _make_test_video(path, n_frames=16)
+            frames = extract_sample_frames(path, count=8)
+            assert len(frames) == 8
+            for frame in frames:
+                assert isinstance(frame, np.ndarray)
+                assert frame.shape == (240, 320, 3)
+        finally:
+            os.unlink(path)
+
+    def test_handles_nonexistent_video(self):
+        frames = extract_sample_frames("/nonexistent/video.mp4", count=8)
+        assert frames == []
+
+
+class TestBuildTimelineSvg:
+    def test_produces_rect_elements(self):
+        svg = _build_timeline_svg([1, 3, 2, 5, 4])
+        assert "<rect" in svg
+        assert "<svg" in svg
+
+    def test_empty_data(self):
+        result = _build_timeline_svg([])
+        assert "No data" in result
+
+
+class TestShowcaseReporter:
+    def test_generates_html_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            results = _make_sample_results(10)
+            stats = ShowcaseStats.from_results(results, fps=10.0)
+
+            # Create sample frames (plain colored frames)
+            sample_frames = [
+                np.full((240, 320, 3), i * 30 % 256, dtype=np.uint8)
+                for i in range(8)
+            ]
+
+            report_path = ShowcaseReporter.generate(stats, sample_frames, tmpdir)
+            assert os.path.exists(report_path)
+            assert report_path.endswith("report.html")
+
+    def test_html_contains_stats(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            results = _make_sample_results(10)
+            stats = ShowcaseStats.from_results(results, fps=10.0)
+            sample_frames = [
+                np.full((240, 320, 3), 128, dtype=np.uint8) for _ in range(8)
+            ]
+
+            report_path = ShowcaseReporter.generate(stats, sample_frames, tmpdir)
+            html = open(report_path).read()
+
+            assert str(stats.total_frames) in html
+            assert str(stats.total_detections) in html
+            assert "person" in html
+
+    def test_html_contains_base64_images(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            results = _make_sample_results(10)
+            stats = ShowcaseStats.from_results(results, fps=10.0)
+            sample_frames = [
+                np.full((240, 320, 3), 128, dtype=np.uint8) for _ in range(8)
+            ]
+
+            report_path = ShowcaseReporter.generate(stats, sample_frames, tmpdir)
+            html = open(report_path).read()
+
+            assert html.count("data:image/png;base64,") == 8
+
+    def test_html_contains_svg_timeline(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            results = _make_sample_results(10)
+            stats = ShowcaseStats.from_results(results, fps=10.0)
+            sample_frames = [
+                np.full((240, 320, 3), 128, dtype=np.uint8) for _ in range(8)
+            ]
+
+            report_path = ShowcaseReporter.generate(stats, sample_frames, tmpdir)
+            html = open(report_path).read()
+
+            assert "<rect" in html
+            assert "<svg" in html

--- a/tests/test_showcase_annotator.py
+++ b/tests/test_showcase_annotator.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import numpy as np
+import supervision as sv
+
+from dino.annotation.annotator import FrameAnnotator
+from dino.annotation.showcase_annotator import ShowcaseAnnotator
+
+
+class TestShowcaseAnnotator:
+    def _make_frame(self, h: int = 480, w: int = 640) -> np.ndarray:
+        return np.zeros((h, w, 3), dtype=np.uint8)
+
+    def _make_detections(self, n: int = 3) -> sv.Detections:
+        xyxy = np.array([[10 * i, 10 * i, 50 + 10 * i, 50 + 10 * i] for i in range(n)], dtype=np.float32)
+        return sv.Detections(
+            xyxy=xyxy,
+            confidence=np.array([0.9] * n, dtype=np.float32),
+            class_id=np.array(list(range(n)), dtype=int),
+            data={"class_name": np.array(["person", "table", "plate"][:n])},
+        )
+
+    def test_is_subclass_of_frame_annotator(self):
+        assert issubclass(ShowcaseAnnotator, FrameAnnotator)
+
+    def test_annotate_returns_numpy_array(self):
+        annotator = ShowcaseAnnotator(prompts=["person", "table", "plate"])
+        frame = self._make_frame()
+        detections = self._make_detections()
+        result = annotator.annotate(frame, detections)
+        assert isinstance(result, np.ndarray)
+        assert result.shape == frame.shape
+
+    def test_hud_differs_from_base(self):
+        """ShowcaseAnnotator output should differ from base due to HUD overlay."""
+        frame = self._make_frame()
+        detections = self._make_detections()
+
+        base = FrameAnnotator()
+        base_result = base.annotate(frame, detections)
+
+        showcase = ShowcaseAnnotator(prompts=["person", "table", "plate"])
+        showcase_result = showcase.annotate(frame, detections)
+
+        assert not np.array_equal(base_result, showcase_result)
+
+    def test_color_lookup_is_class(self):
+        annotator = ShowcaseAnnotator(prompts=["person"])
+        assert annotator._box_annotator.color_lookup == sv.ColorLookup.CLASS
+        assert annotator._label_annotator.color_lookup == sv.ColorLookup.CLASS
+        assert annotator._trace_annotator.color_lookup == sv.ColorLookup.CLASS
+
+    def test_works_with_empty_detections(self):
+        annotator = ShowcaseAnnotator(prompts=["person"])
+        frame = self._make_frame()
+        detections = sv.Detections.empty()
+        result = annotator.annotate(frame, detections)
+        assert isinstance(result, np.ndarray)
+        assert result.shape == frame.shape
+
+    def test_does_not_modify_original_frame(self):
+        annotator = ShowcaseAnnotator(prompts=["person", "table"])
+        frame = self._make_frame()
+        original = frame.copy()
+        detections = self._make_detections(2)
+        annotator.annotate(frame, detections)
+        np.testing.assert_array_equal(frame, original)


### PR DESCRIPTION
## Summary

- **ShowcaseAnnotator**: Extends `FrameAnnotator` with per-class color coding (`ColorLookup.CLASS`) and a semi-transparent HUD overlay displaying detection counts and per-class breakdown
- **VideoPipeline.run()**: Added optional `progress_callback` and `sbs_output` parameters — no breaking changes to existing callers
- **ShowcaseReporter**: Generates a self-contained HTML report with stats dashboard, inline SVG detection timeline, base64 sample frame gallery, and class breakdown table
- **demo_showcase.py**: CLI entry point with tqdm progress bar, producing `annotated.mp4`, `side_by_side.mp4`, `results.json`, and `report.html`
- Added `tqdm` dependency
- 17 new tests (67 total, all passing)

Fixes #16

## Test plan

- [x] `uv sync` succeeds
- [x] `uv run pytest tests/` — all 67 tests pass (50 existing + 17 new)
- [ ] `uv run python scripts/demo_showcase.py --input <video> --output-dir data/output/showcase/` — verify annotated video has color-coded boxes + HUD, side-by-side video renders correctly, HTML report opens in browser with stats/timeline/frames
- [ ] Existing `run_pipeline.py` still works unchanged (no breaking changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)