### PR TITLE
Add spatial foundation: models, localizers, projection, registry

### DIFF
--- a/src/dino/spatial/base_localizer.py
+++ b/src/dino/spatial/base_localizer.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+import supervision as sv
+
+from dino.spatial.models import WorldObject
+
+
+class BaseLocalizer(ABC):
+    """Abstract base for all localizers.
+
+    Converts 2D pixel-space detections to world-space objects.
+    """
+
+    @abstractmethod
+    def localize(
+        self, detections: sv.Detections, frame: np.ndarray, frame_idx: int
+    ) -> list[WorldObject]:
+        """Convert 2D detections to world-space objects.
+
+        Args:
+            detections: sv.Detections with xyxy boxes and optional metadata.
+            frame: BGR image as numpy array (H, W, 3).
+            frame_idx: Current frame index.
+
+        Returns:
+            List of WorldObject instances with world_position set.
+        """

--- a/src/dino/spatial/fixed_camera_localizer.py
+++ b/src/dino/spatial/fixed_camera_localizer.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import numpy as np
+import supervision as sv
+
+from dino.spatial.base_localizer import BaseLocalizer
+from dino.spatial.models import WorldObject
+
+
+class FixedCameraLocalizer(BaseLocalizer):
+    """Localizer for fixed/CCTV cameras.
+
+    Identity mapping: world_position = bbox center in pixels [cx, cy, 0.0].
+    No depth estimation or model loading required.
+    """
+
+    def localize(
+        self, detections: sv.Detections, frame: np.ndarray, frame_idx: int
+    ) -> list[WorldObject]:
+        objects = []
+        for i in range(len(detections)):
+            x1, y1, x2, y2 = detections.xyxy[i]
+            cx = (x1 + x2) / 2.0
+            cy = (y1 + y2) / 2.0
+
+            obj = WorldObject(
+                tracker_id=(
+                    int(detections.tracker_id[i])
+                    if detections.tracker_id is not None
+                    else -1
+                ),
+                bbox_xyxy=detections.xyxy[i].copy(),
+                world_position=np.array([cx, cy, 0.0]),
+                class_name=(
+                    str(detections.data["class_name"][i])
+                    if "class_name" in detections.data
+                    else ""
+                ),
+                class_id=(
+                    int(detections.class_id[i])
+                    if detections.class_id is not None
+                    else -1
+                ),
+                confidence=(
+                    float(detections.confidence[i])
+                    if detections.confidence is not None
+                    else 0.0
+                ),
+                frame_idx=frame_idx,
+            )
+            objects.append(obj)
+        return objects

--- a/src/dino/spatial/models.py
+++ b/src/dino/spatial/models.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class CameraIntrinsics:
+    """Pinhole camera intrinsic parameters."""
+
+    fx: float
+    fy: float
+    cx: float
+    cy: float
+    width: int
+    height: int
+
+
+@dataclass
+class CameraPose:
+    """Camera extrinsic parameters (world-from-camera transform)."""
+
+    translation: np.ndarray  # (3,) world position
+    rotation: np.ndarray  # (3,3) rotation matrix
+    frame_idx: int
+    timestamp: float = 0.0
+
+
+@dataclass
+class WorldObject:
+    """A detected object with world-space position."""
+
+    tracker_id: int
+    bbox_xyxy: np.ndarray  # (4,) pixel-space bounding box
+    world_position: np.ndarray  # (3,) world-space position [x,y,z]
+    persistent_id: int | None = None
+    class_name: str = ""
+    class_id: int = -1
+    confidence: float = 0.0
+    position_confidence: float = 1.0
+    frame_idx: int = 0
+    timestamp: float = 0.0
+    zone_id: str | None = None

--- a/src/dino/spatial/models.py
+++ b/src/dino/spatial/models.py
@@ -16,6 +16,16 @@ class CameraIntrinsics:
     width: int
     height: int
 
+    def __post_init__(self) -> None:
+        if self.fx <= 0 or self.fy <= 0:
+            raise ValueError(
+                f"focal lengths must be positive, got fx={self.fx}, fy={self.fy}"
+            )
+        if self.width <= 0 or self.height <= 0:
+            raise ValueError(
+                f"dimensions must be positive, got {self.width}x{self.height}"
+            )
+
 
 @dataclass
 class CameraPose:
@@ -25,6 +35,16 @@ class CameraPose:
     rotation: np.ndarray  # (3,3) rotation matrix
     frame_idx: int
     timestamp: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.translation.shape != (3,):
+            raise ValueError(
+                f"translation must be shape (3,), got {self.translation.shape}"
+            )
+        if self.rotation.shape != (3, 3):
+            raise ValueError(
+                f"rotation must be shape (3,3), got {self.rotation.shape}"
+            )
 
 
 @dataclass

--- a/src/dino/spatial/projection.py
+++ b/src/dino/spatial/projection.py
@@ -6,7 +6,18 @@ from dino.spatial.models import CameraIntrinsics, CameraPose
 
 
 def quaternion_to_rotation_matrix(q: np.ndarray) -> np.ndarray:
-    """Convert quaternion [w, x, y, z] to 3x3 rotation matrix."""
+    """Convert quaternion [w, x, y, z] to 3x3 rotation matrix.
+
+    The quaternion is normalized before conversion to ensure a valid
+    rotation matrix even if the input is not exactly unit length.
+
+    Raises:
+        ValueError: If the quaternion has near-zero norm.
+    """
+    norm = float(np.linalg.norm(q))
+    if norm < 1e-10:
+        raise ValueError(f"quaternion has near-zero norm ({norm})")
+    q = q / norm
     w, x, y, z = q
     return np.array([
         [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
@@ -25,6 +36,8 @@ def backproject_pixel_to_camera(
     Returns:
         (3,) array [X, Y, Z] in camera frame.
     """
+    if depth <= 0:
+        raise ValueError(f"depth must be positive, got {depth}")
     x = (u - intrinsics.cx) * depth / intrinsics.fx
     y = (v - intrinsics.cy) * depth / intrinsics.fy
     z = depth

--- a/src/dino/spatial/projection.py
+++ b/src/dino/spatial/projection.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import numpy as np
+
+from dino.spatial.models import CameraIntrinsics, CameraPose
+
+
+def quaternion_to_rotation_matrix(q: np.ndarray) -> np.ndarray:
+    """Convert quaternion [w, x, y, z] to 3x3 rotation matrix."""
+    w, x, y, z = q
+    return np.array([
+        [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+        [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+        [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+    ])
+
+
+def backproject_pixel_to_camera(
+    u: float, v: float, depth: float, intrinsics: CameraIntrinsics
+) -> np.ndarray:
+    """Backproject a pixel (u, v) at given depth to camera-frame 3D point.
+
+    Uses pinhole camera model: X = (u - cx) * depth / fx, etc.
+
+    Returns:
+        (3,) array [X, Y, Z] in camera frame.
+    """
+    x = (u - intrinsics.cx) * depth / intrinsics.fx
+    y = (v - intrinsics.cy) * depth / intrinsics.fy
+    z = depth
+    return np.array([x, y, z])
+
+
+def camera_to_world(
+    point_camera: np.ndarray, pose: CameraPose
+) -> np.ndarray:
+    """Transform a point from camera frame to world frame.
+
+    Args:
+        point_camera: (3,) point in camera coordinates.
+        pose: CameraPose with rotation (world-from-camera) and translation.
+
+    Returns:
+        (3,) point in world coordinates: R @ p + t
+    """
+    return pose.rotation @ point_camera + pose.translation
+
+
+def backproject_to_world(
+    u: float,
+    v: float,
+    depth: float,
+    intrinsics: CameraIntrinsics,
+    pose: CameraPose,
+) -> np.ndarray:
+    """Full pipeline: pixel (u,v) + depth -> world-space 3D point."""
+    point_camera = backproject_pixel_to_camera(u, v, depth, intrinsics)
+    return camera_to_world(point_camera, pose)

--- a/src/dino/spatial/registry.py
+++ b/src/dino/spatial/registry.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 
 from dino.spatial.models import WorldObject
+
+logger = logging.getLogger(__name__)
 
 
 class SpatialObjectRegistry:
@@ -17,6 +21,10 @@ class SpatialObjectRegistry:
         match_distance: float = 50.0,
         max_age_seconds: float = 30.0,
     ):
+        if match_distance <= 0:
+            raise ValueError(f"match_distance must be positive, got {match_distance}")
+        if max_age_seconds <= 0:
+            raise ValueError(f"max_age_seconds must be positive, got {max_age_seconds}")
         self.match_distance = match_distance
         self.max_age_seconds = max_age_seconds
         self._next_id: int = 0
@@ -41,11 +49,19 @@ class SpatialObjectRegistry:
             if pid in self._objects:
                 return self._update(obj, pid)
             # Stale mapping — fall through to slow path
+            logger.debug(
+                "Stale tracker mapping: tracker_id=%d -> persistent_id=%d (evicted)",
+                obj.tracker_id, pid,
+            )
             del self._tracker_to_persistent[obj.tracker_id]
 
         # Slow path: proximity match
         best_pid = self._find_nearest(obj)
         if best_pid is not None:
+            logger.debug(
+                "Proximity re-ID: tracker_id=%d -> persistent_id=%d",
+                obj.tracker_id, best_pid,
+            )
             self._tracker_to_persistent[obj.tracker_id] = best_pid
             return self._update(obj, best_pid)
 
@@ -53,6 +69,10 @@ class SpatialObjectRegistry:
         pid = self._next_id
         self._next_id += 1
         self._tracker_to_persistent[obj.tracker_id] = pid
+        logger.debug(
+            "New object: tracker_id=%d -> persistent_id=%d (%s)",
+            obj.tracker_id, pid, obj.class_name,
+        )
         return self._update(obj, pid)
 
     def _update(self, obj: WorldObject, persistent_id: int) -> WorldObject:
@@ -78,10 +98,15 @@ class SpatialObjectRegistry:
             for pid, obj in self._objects.items()
             if current_time - obj.timestamp > self.max_age_seconds
         ]
+        if not stale:
+            return
+        stale_set = set(stale)
         for pid in stale:
+            logger.debug("Evicting persistent_id=%d (aged out)", pid)
             del self._objects[pid]
-            self._tracker_to_persistent = {
-                tid: p
-                for tid, p in self._tracker_to_persistent.items()
-                if p != pid
-            }
+        # Single-pass cleanup of tracker mappings
+        self._tracker_to_persistent = {
+            tid: p
+            for tid, p in self._tracker_to_persistent.items()
+            if p not in stale_set
+        }

--- a/src/dino/spatial/registry.py
+++ b/src/dino/spatial/registry.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import numpy as np
+
+from dino.spatial.models import WorldObject
+
+
+class SpatialObjectRegistry:
+    """Persistent object identity via 3D proximity matching.
+
+    Maintains a registry of known objects and matches incoming detections
+    to existing objects for persistent identity across tracker re-IDs.
+    """
+
+    def __init__(
+        self,
+        match_distance: float = 50.0,
+        max_age_seconds: float = 30.0,
+    ):
+        self.match_distance = match_distance
+        self.max_age_seconds = max_age_seconds
+        self._next_id: int = 0
+        self._tracker_to_persistent: dict[int, int] = {}
+        self._objects: dict[int, WorldObject] = {}  # persistent_id -> last WorldObject
+
+    def register(self, obj: WorldObject) -> WorldObject:
+        """Register a world object and assign persistent identity.
+
+        1. Fast path: tracker_id already mapped -> reuse persistent_id.
+        2. Slow path: find nearest known object (same class, within match_distance).
+        3. New object: allocate new persistent_id.
+
+        Returns:
+            WorldObject with persistent_id set.
+        """
+        self._evict(obj.timestamp)
+
+        # Fast path: tracker_id already known
+        if obj.tracker_id in self._tracker_to_persistent:
+            pid = self._tracker_to_persistent[obj.tracker_id]
+            if pid in self._objects:
+                return self._update(obj, pid)
+            # Stale mapping — fall through to slow path
+            del self._tracker_to_persistent[obj.tracker_id]
+
+        # Slow path: proximity match
+        best_pid = self._find_nearest(obj)
+        if best_pid is not None:
+            self._tracker_to_persistent[obj.tracker_id] = best_pid
+            return self._update(obj, best_pid)
+
+        # New object
+        pid = self._next_id
+        self._next_id += 1
+        self._tracker_to_persistent[obj.tracker_id] = pid
+        return self._update(obj, pid)
+
+    def _update(self, obj: WorldObject, persistent_id: int) -> WorldObject:
+        obj.persistent_id = persistent_id
+        self._objects[persistent_id] = obj
+        return obj
+
+    def _find_nearest(self, obj: WorldObject) -> int | None:
+        best_dist = self.match_distance
+        best_pid = None
+        for pid, known in self._objects.items():
+            if known.class_name != obj.class_name:
+                continue
+            dist = float(np.linalg.norm(obj.world_position - known.world_position))
+            if dist < best_dist:
+                best_dist = dist
+                best_pid = pid
+        return best_pid
+
+    def _evict(self, current_time: float) -> None:
+        stale = [
+            pid
+            for pid, obj in self._objects.items()
+            if current_time - obj.timestamp > self.max_age_seconds
+        ]
+        for pid in stale:
+            del self._objects[pid]
+            self._tracker_to_persistent = {
+                tid: p
+                for tid, p in self._tracker_to_persistent.items()
+                if p != pid
+            }

--- a/tests/test_fixed_localizer.py
+++ b/tests/test_fixed_localizer.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import supervision as sv
+
+from dino.spatial.base_localizer import BaseLocalizer
+from dino.spatial.fixed_camera_localizer import FixedCameraLocalizer
+
+
+def _make_frame(h: int = 480, w: int = 640) -> np.ndarray:
+    return np.zeros((h, w, 3), dtype=np.uint8)
+
+
+class TestBaseLocalizer:
+    def test_cannot_instantiate(self):
+        with pytest.raises(TypeError):
+            BaseLocalizer()
+
+
+class TestFixedCameraLocalizer:
+    def test_localize_single_detection(self):
+        localizer = FixedCameraLocalizer()
+        detections = sv.Detections(
+            xyxy=np.array([[10, 20, 110, 220]], dtype=np.float32),
+            tracker_id=np.array([1]),
+        )
+        frame = _make_frame()
+        objects = localizer.localize(detections, frame, frame_idx=0)
+
+        assert len(objects) == 1
+        np.testing.assert_array_almost_equal(
+            objects[0].world_position, [60.0, 120.0, 0.0]
+        )
+
+    def test_localize_multiple_detections(self):
+        localizer = FixedCameraLocalizer()
+        detections = sv.Detections(
+            xyxy=np.array(
+                [[0, 0, 100, 100], [200, 200, 400, 400]], dtype=np.float32
+            ),
+            tracker_id=np.array([1, 2]),
+        )
+        frame = _make_frame()
+        objects = localizer.localize(detections, frame, frame_idx=0)
+
+        assert len(objects) == 2
+        np.testing.assert_array_almost_equal(
+            objects[0].world_position, [50.0, 50.0, 0.0]
+        )
+        np.testing.assert_array_almost_equal(
+            objects[1].world_position, [300.0, 300.0, 0.0]
+        )
+
+    def test_localize_empty_detections(self):
+        localizer = FixedCameraLocalizer()
+        detections = sv.Detections.empty()
+        frame = _make_frame()
+        objects = localizer.localize(detections, frame, frame_idx=0)
+
+        assert len(objects) == 0
+
+    def test_preserves_class_info(self):
+        localizer = FixedCameraLocalizer()
+        detections = sv.Detections(
+            xyxy=np.array([[10, 20, 100, 200]], dtype=np.float32),
+            confidence=np.array([0.85]),
+            class_id=np.array([2]),
+            tracker_id=np.array([7]),
+            data={"class_name": np.array(["person"])},
+        )
+        frame = _make_frame()
+        objects = localizer.localize(detections, frame, frame_idx=0)
+
+        assert objects[0].class_name == "person"
+        assert objects[0].class_id == 2
+        assert objects[0].confidence == pytest.approx(0.85)
+
+    def test_preserves_tracker_id(self):
+        localizer = FixedCameraLocalizer()
+        detections = sv.Detections(
+            xyxy=np.array([[10, 20, 100, 200]], dtype=np.float32),
+            tracker_id=np.array([42]),
+        )
+        frame = _make_frame()
+        objects = localizer.localize(detections, frame, frame_idx=0)
+
+        assert objects[0].tracker_id == 42
+
+    def test_frame_idx_passed_through(self):
+        localizer = FixedCameraLocalizer()
+        detections = sv.Detections(
+            xyxy=np.array([[10, 20, 100, 200]], dtype=np.float32),
+            tracker_id=np.array([1]),
+        )
+        frame = _make_frame()
+        objects = localizer.localize(detections, frame, frame_idx=99)
+
+        assert objects[0].frame_idx == 99

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from dino.spatial.models import CameraIntrinsics, CameraPose
+from dino.spatial.projection import (
+    backproject_pixel_to_camera,
+    backproject_to_world,
+    camera_to_world,
+    quaternion_to_rotation_matrix,
+)
+
+
+class TestQuaternionToRotationMatrix:
+    def test_identity_quaternion(self):
+        q = np.array([1.0, 0.0, 0.0, 0.0])
+        R = quaternion_to_rotation_matrix(q)
+        np.testing.assert_array_almost_equal(R, np.eye(3))
+
+    def test_90_degree_rotation_z(self):
+        angle = math.pi / 2
+        q = np.array([math.cos(angle / 2), 0.0, 0.0, math.sin(angle / 2)])
+        R = quaternion_to_rotation_matrix(q)
+        # Rotating [1, 0, 0] by 90 degrees around Z should give [0, 1, 0]
+        result = R @ np.array([1.0, 0.0, 0.0])
+        np.testing.assert_array_almost_equal(result, [0.0, 1.0, 0.0])
+
+    def test_output_shape(self):
+        q = np.array([1.0, 0.0, 0.0, 0.0])
+        R = quaternion_to_rotation_matrix(q)
+        assert R.shape == (3, 3)
+
+    def test_orthogonal(self):
+        angle = 1.23
+        q = np.array([
+            math.cos(angle / 2),
+            math.sin(angle / 2) * 0.267,
+            math.sin(angle / 2) * 0.535,
+            math.sin(angle / 2) * 0.802,
+        ])
+        # Normalize quaternion
+        q = q / np.linalg.norm(q)
+        R = quaternion_to_rotation_matrix(q)
+        np.testing.assert_array_almost_equal(R @ R.T, np.eye(3), decimal=6)
+        assert abs(np.linalg.det(R) - 1.0) < 1e-6
+
+
+class TestBackprojectPixelToCamera:
+    def test_principal_point_at_unit_depth(self):
+        intrinsics = CameraIntrinsics(
+            fx=500.0, fy=500.0, cx=320.0, cy=240.0, width=640, height=480
+        )
+        point = backproject_pixel_to_camera(320.0, 240.0, 1.0, intrinsics)
+        np.testing.assert_array_almost_equal(point, [0.0, 0.0, 1.0])
+
+    def test_offset_pixel(self):
+        intrinsics = CameraIntrinsics(
+            fx=500.0, fy=500.0, cx=320.0, cy=240.0, width=640, height=480
+        )
+        point = backproject_pixel_to_camera(820.0, 740.0, 1.0, intrinsics)
+        np.testing.assert_array_almost_equal(point, [1.0, 1.0, 1.0])
+
+    def test_depth_scaling(self):
+        intrinsics = CameraIntrinsics(
+            fx=500.0, fy=500.0, cx=320.0, cy=240.0, width=640, height=480
+        )
+        p1 = backproject_pixel_to_camera(420.0, 340.0, 1.0, intrinsics)
+        p2 = backproject_pixel_to_camera(420.0, 340.0, 2.0, intrinsics)
+        np.testing.assert_array_almost_equal(p2[:2], p1[:2] * 2.0)
+
+
+class TestCameraToWorld:
+    def test_identity_pose(self):
+        pose = CameraPose(
+            translation=np.zeros(3), rotation=np.eye(3), frame_idx=0
+        )
+        point = np.array([1.0, 2.0, 3.0])
+        result = camera_to_world(point, pose)
+        np.testing.assert_array_almost_equal(result, point)
+
+    def test_translation_only(self):
+        pose = CameraPose(
+            translation=np.array([1.0, 2.0, 3.0]),
+            rotation=np.eye(3),
+            frame_idx=0,
+        )
+        point = np.array([0.0, 0.0, 0.0])
+        result = camera_to_world(point, pose)
+        np.testing.assert_array_almost_equal(result, [1.0, 2.0, 3.0])
+
+    def test_rotation_and_translation(self):
+        # 90 degree rotation around Z axis
+        R = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+        pose = CameraPose(
+            translation=np.array([10.0, 20.0, 0.0]),
+            rotation=R,
+            frame_idx=0,
+        )
+        point = np.array([1.0, 0.0, 0.0])
+        result = camera_to_world(point, pose)
+        # R @ [1,0,0] = [0,1,0], then + [10,20,0] = [10,21,0]
+        np.testing.assert_array_almost_equal(result, [10.0, 21.0, 0.0])
+
+
+class TestBackprojectToWorld:
+    def test_principal_point_identity_pose(self):
+        intrinsics = CameraIntrinsics(
+            fx=500.0, fy=500.0, cx=320.0, cy=240.0, width=640, height=480
+        )
+        pose = CameraPose(
+            translation=np.zeros(3), rotation=np.eye(3), frame_idx=0
+        )
+        result = backproject_to_world(320.0, 240.0, 5.0, intrinsics, pose)
+        np.testing.assert_array_almost_equal(result, [0.0, 0.0, 5.0])
+
+    def test_round_trip(self):
+        intrinsics = CameraIntrinsics(
+            fx=500.0, fy=500.0, cx=320.0, cy=240.0, width=640, height=480
+        )
+        pose = CameraPose(
+            translation=np.array([1.0, 2.0, 3.0]),
+            rotation=np.eye(3),
+            frame_idx=0,
+        )
+        result = backproject_to_world(420.0, 340.0, 5.0, intrinsics, pose)
+        # Camera point: ((420-320)*5/500, (340-240)*5/500, 5) = (1.0, 1.0, 5.0)
+        # World point: (1.0, 1.0, 5.0) + (1.0, 2.0, 3.0) = (2.0, 3.0, 8.0)
+        np.testing.assert_array_almost_equal(result, [2.0, 3.0, 8.0])

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -47,6 +47,17 @@ class TestQuaternionToRotationMatrix:
         np.testing.assert_array_almost_equal(R @ R.T, np.eye(3), decimal=6)
         assert abs(np.linalg.det(R) - 1.0) < 1e-6
 
+    def test_zero_quaternion_raises(self):
+        q = np.array([0.0, 0.0, 0.0, 0.0])
+        with pytest.raises(ValueError, match="near-zero norm"):
+            quaternion_to_rotation_matrix(q)
+
+    def test_unnormalized_quaternion_still_valid(self):
+        """Non-unit quaternion should be auto-normalized."""
+        q = np.array([2.0, 0.0, 0.0, 0.0])  # scale of 2
+        R = quaternion_to_rotation_matrix(q)
+        np.testing.assert_array_almost_equal(R, np.eye(3))
+
 
 class TestBackprojectPixelToCamera:
     def test_principal_point_at_unit_depth(self):
@@ -70,6 +81,20 @@ class TestBackprojectPixelToCamera:
         p1 = backproject_pixel_to_camera(420.0, 340.0, 1.0, intrinsics)
         p2 = backproject_pixel_to_camera(420.0, 340.0, 2.0, intrinsics)
         np.testing.assert_array_almost_equal(p2[:2], p1[:2] * 2.0)
+
+    def test_zero_depth_raises(self):
+        intrinsics = CameraIntrinsics(
+            fx=500.0, fy=500.0, cx=320.0, cy=240.0, width=640, height=480
+        )
+        with pytest.raises(ValueError, match="depth must be positive"):
+            backproject_pixel_to_camera(320.0, 240.0, 0.0, intrinsics)
+
+    def test_negative_depth_raises(self):
+        intrinsics = CameraIntrinsics(
+            fx=500.0, fy=500.0, cx=320.0, cy=240.0, width=640, height=480
+        )
+        with pytest.raises(ValueError, match="depth must be positive"):
+            backproject_pixel_to_camera(320.0, 240.0, -1.0, intrinsics)
 
 
 class TestCameraToWorld:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from dino.spatial.models import WorldObject
+from dino.spatial.registry import SpatialObjectRegistry
+
+
+def _make_object(
+    tracker_id: int = 1,
+    position: tuple[float, float, float] = (50.0, 50.0, 0.0),
+    class_name: str = "person",
+    timestamp: float = 0.0,
+) -> WorldObject:
+    return WorldObject(
+        tracker_id=tracker_id,
+        bbox_xyxy=np.array([0, 0, 100, 100], dtype=np.float32),
+        world_position=np.array(position),
+        class_name=class_name,
+        timestamp=timestamp,
+    )
+
+
+class TestSpatialObjectRegistry:
+    def test_register_new_object(self):
+        registry = SpatialObjectRegistry()
+        obj = _make_object(tracker_id=1)
+        result = registry.register(obj)
+        assert result.persistent_id == 0
+
+    def test_tracker_id_cache_hit(self):
+        registry = SpatialObjectRegistry()
+        obj1 = _make_object(tracker_id=1, timestamp=0.0)
+        obj2 = _make_object(tracker_id=1, timestamp=1.0)
+        r1 = registry.register(obj1)
+        r2 = registry.register(obj2)
+        assert r1.persistent_id == r2.persistent_id
+
+    def test_proximity_match(self):
+        registry = SpatialObjectRegistry(match_distance=100.0)
+        obj1 = _make_object(tracker_id=1, position=(50.0, 50.0, 0.0), timestamp=0.0)
+        obj2 = _make_object(
+            tracker_id=99, position=(55.0, 55.0, 0.0), timestamp=1.0
+        )
+        r1 = registry.register(obj1)
+        r2 = registry.register(obj2)
+        assert r1.persistent_id == r2.persistent_id
+
+    def test_proximity_no_match_different_class(self):
+        registry = SpatialObjectRegistry(match_distance=100.0)
+        obj1 = _make_object(
+            tracker_id=1, position=(50.0, 50.0, 0.0), class_name="person"
+        )
+        obj2 = _make_object(
+            tracker_id=2, position=(55.0, 55.0, 0.0), class_name="cup"
+        )
+        r1 = registry.register(obj1)
+        r2 = registry.register(obj2)
+        assert r1.persistent_id != r2.persistent_id
+
+    def test_proximity_no_match_too_far(self):
+        registry = SpatialObjectRegistry(match_distance=10.0)
+        obj1 = _make_object(tracker_id=1, position=(0.0, 0.0, 0.0))
+        obj2 = _make_object(tracker_id=2, position=(100.0, 100.0, 0.0))
+        r1 = registry.register(obj1)
+        r2 = registry.register(obj2)
+        assert r1.persistent_id != r2.persistent_id
+
+    def test_eviction(self):
+        registry = SpatialObjectRegistry(
+            match_distance=100.0, max_age_seconds=5.0
+        )
+        obj1 = _make_object(tracker_id=1, position=(50.0, 50.0, 0.0), timestamp=0.0)
+        r1 = registry.register(obj1)
+        pid1 = r1.persistent_id
+
+        # Same position but after eviction window, new tracker
+        obj2 = _make_object(
+            tracker_id=2, position=(50.0, 50.0, 0.0), timestamp=10.0
+        )
+        r2 = registry.register(obj2)
+        assert r2.persistent_id != pid1
+
+    def test_multiple_objects(self):
+        registry = SpatialObjectRegistry()
+        ids = set()
+        for i in range(3):
+            obj = _make_object(
+                tracker_id=i, position=(i * 200.0, 0.0, 0.0)
+            )
+            r = registry.register(obj)
+            ids.add(r.persistent_id)
+        assert len(ids) == 3
+
+    def test_register_returns_updated_object(self):
+        registry = SpatialObjectRegistry()
+        obj = _make_object(tracker_id=1)
+        result = registry.register(obj)
+        assert result.persistent_id is not None
+        assert result is obj

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -99,3 +99,51 @@ class TestSpatialObjectRegistry:
         result = registry.register(obj)
         assert result.persistent_id is not None
         assert result is obj
+
+    def test_stale_tracker_mapping_falls_through(self):
+        """Tracker mapping to evicted object falls through to proximity/new."""
+        registry = SpatialObjectRegistry(match_distance=100.0, max_age_seconds=5.0)
+        # Register object with tracker_id=1
+        obj1 = _make_object(tracker_id=1, position=(50.0, 50.0, 0.0), timestamp=0.0)
+        r1 = registry.register(obj1)
+        pid1 = r1.persistent_id
+
+        # Object gets evicted, but tracker_id=1 appears again far away
+        obj2 = _make_object(
+            tracker_id=1, position=(500.0, 500.0, 0.0), timestamp=10.0
+        )
+        r2 = registry.register(obj2)
+        # Should get new persistent_id since old was evicted
+        assert r2.persistent_id != pid1
+
+    def test_eviction_cleans_tracker_mappings(self):
+        """Eviction should clean up corresponding tracker-to-persistent mappings."""
+        registry = SpatialObjectRegistry(match_distance=100.0, max_age_seconds=5.0)
+        obj1 = _make_object(tracker_id=1, position=(50.0, 50.0, 0.0), timestamp=0.0)
+        registry.register(obj1)
+        assert 1 in registry._tracker_to_persistent
+
+        # Trigger eviction
+        obj2 = _make_object(tracker_id=2, position=(500.0, 500.0, 0.0), timestamp=10.0)
+        registry.register(obj2)
+        # tracker_id=1 mapping should be cleaned up
+        assert 1 not in registry._tracker_to_persistent
+
+    def test_constructor_validation(self):
+        with pytest.raises(ValueError, match="match_distance"):
+            SpatialObjectRegistry(match_distance=0)
+        with pytest.raises(ValueError, match="max_age_seconds"):
+            SpatialObjectRegistry(max_age_seconds=-1)
+
+    def test_nearest_among_multiple_candidates(self):
+        """When multiple objects of same class exist, nearest one wins."""
+        registry = SpatialObjectRegistry(match_distance=100.0)
+        obj_a = _make_object(tracker_id=1, position=(0.0, 0.0, 0.0), timestamp=0.0)
+        obj_b = _make_object(tracker_id=2, position=(50.0, 0.0, 0.0), timestamp=0.0)
+        r_a = registry.register(obj_a)
+        r_b = registry.register(obj_b)
+
+        # New object closer to B
+        obj_c = _make_object(tracker_id=3, position=(48.0, 0.0, 0.0), timestamp=1.0)
+        r_c = registry.register(obj_c)
+        assert r_c.persistent_id == r_b.persistent_id

--- a/tests/test_spatial_models.py
+++ b/tests/test_spatial_models.py
@@ -61,6 +61,18 @@ class TestCameraIntrinsics:
         with pytest.raises(AttributeError):
             intrinsics.fx = 600.0
 
+    def test_zero_focal_length_raises(self):
+        with pytest.raises(ValueError, match="focal lengths"):
+            CameraIntrinsics(fx=0, fy=500.0, cx=320.0, cy=240.0, width=640, height=480)
+
+    def test_negative_focal_length_raises(self):
+        with pytest.raises(ValueError, match="focal lengths"):
+            CameraIntrinsics(fx=-1, fy=500.0, cx=320.0, cy=240.0, width=640, height=480)
+
+    def test_zero_dimensions_raises(self):
+        with pytest.raises(ValueError, match="dimensions"):
+            CameraIntrinsics(fx=500.0, fy=500.0, cx=320.0, cy=240.0, width=0, height=480)
+
 
 class TestCameraPose:
     def test_construction(self):
@@ -80,3 +92,19 @@ class TestCameraPose:
             frame_idx=0,
         )
         assert pose.timestamp == 0.0
+
+    def test_bad_translation_shape_raises(self):
+        with pytest.raises(ValueError, match="translation"):
+            CameraPose(
+                translation=np.zeros(4),
+                rotation=np.eye(3),
+                frame_idx=0,
+            )
+
+    def test_bad_rotation_shape_raises(self):
+        with pytest.raises(ValueError, match="rotation"):
+            CameraPose(
+                translation=np.zeros(3),
+                rotation=np.eye(4),
+                frame_idx=0,
+            )

--- a/tests/test_spatial_models.py
+++ b/tests/test_spatial_models.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from dino.spatial.models import CameraIntrinsics, CameraPose, WorldObject
+
+
+class TestWorldObject:
+    def test_construction_with_required_fields(self):
+        obj = WorldObject(
+            tracker_id=1,
+            bbox_xyxy=np.array([10, 20, 100, 200], dtype=np.float32),
+            world_position=np.array([55.0, 110.0, 0.0]),
+        )
+        assert obj.tracker_id == 1
+        assert obj.bbox_xyxy is not None
+        assert obj.world_position is not None
+
+    def test_default_values(self):
+        obj = WorldObject(
+            tracker_id=0,
+            bbox_xyxy=np.array([0, 0, 1, 1], dtype=np.float32),
+            world_position=np.array([0.0, 0.0, 0.0]),
+        )
+        assert obj.persistent_id is None
+        assert obj.class_name == ""
+        assert obj.class_id == -1
+        assert obj.confidence == 0.0
+        assert obj.position_confidence == 1.0
+        assert obj.frame_idx == 0
+        assert obj.timestamp == 0.0
+        assert obj.zone_id is None
+
+    def test_numpy_array_shapes(self):
+        obj = WorldObject(
+            tracker_id=0,
+            bbox_xyxy=np.array([10, 20, 100, 200], dtype=np.float32),
+            world_position=np.array([1.0, 2.0, 3.0]),
+        )
+        assert obj.bbox_xyxy.shape == (4,)
+        assert obj.world_position.shape == (3,)
+
+
+class TestCameraIntrinsics:
+    def test_construction(self):
+        intrinsics = CameraIntrinsics(
+            fx=500.0, fy=500.0, cx=320.0, cy=240.0, width=640, height=480
+        )
+        assert intrinsics.fx == 500.0
+        assert intrinsics.fy == 500.0
+        assert intrinsics.cx == 320.0
+        assert intrinsics.cy == 240.0
+        assert intrinsics.width == 640
+        assert intrinsics.height == 480
+
+    def test_frozen(self):
+        intrinsics = CameraIntrinsics(
+            fx=500.0, fy=500.0, cx=320.0, cy=240.0, width=640, height=480
+        )
+        with pytest.raises(AttributeError):
+            intrinsics.fx = 600.0
+
+
+class TestCameraPose:
+    def test_construction(self):
+        pose = CameraPose(
+            translation=np.array([1.0, 2.0, 3.0]),
+            rotation=np.eye(3),
+            frame_idx=42,
+        )
+        assert pose.translation.shape == (3,)
+        assert pose.rotation.shape == (3, 3)
+        assert pose.frame_idx == 42
+
+    def test_default_timestamp(self):
+        pose = CameraPose(
+            translation=np.zeros(3),
+            rotation=np.eye(3),
+            frame_idx=0,
+        )
+        assert pose.timestamp == 0.0


### PR DESCRIPTION
## Summary

- `WorldObject`, `CameraIntrinsics`, `CameraPose` dataclasses in `spatial/models.py`
- `BaseLocalizer` ABC following existing `BaseDetector` pattern
- `FixedCameraLocalizer` — identity mapping for fixed/CCTV cameras (world_position = bbox center)
- `projection.py` — pure numpy backprojection math (quaternion→rotation, pinhole model)
- `SpatialObjectRegistry` — persistent identity via 3D proximity matching with eviction

## Test plan

- [x] All 131 tests pass (`uv run pytest tests/ -v`)
- [x] New test files: `test_spatial_models.py`, `test_fixed_localizer.py`, `test_projection.py`, `test_registry.py`
- [ ] Review agent checks

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)