### PR TITLE
Fix review findings: identity collision, stale zone_id, validation

### DIFF
--- a/src/dino/spatial/fixed_camera_localizer.py
+++ b/src/dino/spatial/fixed_camera_localizer.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 import supervision as sv
 
 from dino.spatial.base_localizer import BaseLocalizer
 from dino.spatial.models import WorldObject
+
+logger = logging.getLogger(__name__)
 
 
 class FixedCameraLocalizer(BaseLocalizer):
@@ -17,6 +21,13 @@ class FixedCameraLocalizer(BaseLocalizer):
     def localize(
         self, detections: sv.Detections, frame: np.ndarray, frame_idx: int
     ) -> list[WorldObject]:
+        if detections.tracker_id is None and len(detections) > 0:
+            logger.warning(
+                "Detections have no tracker_id — all %d objects will get "
+                "tracker_id=-1, which causes identity collision in the registry. "
+                "Ensure a tracker (e.g., ByteTrack) is in the pipeline.",
+                len(detections),
+            )
         objects = []
         for i in range(len(detections)):
             x1, y1, x2, y2 = detections.xyxy[i]

--- a/src/dino/spatial/registry.py
+++ b/src/dino/spatial/registry.py
@@ -69,6 +69,11 @@ class SpatialObjectRegistry:
                     old_tid = tid
                     break
             if old_tid is not None:
+                logger.debug(
+                    "Cleaning stale tracker mapping: tracker_id=%d was mapped to "
+                    "persistent_id=%d (now owned by tracker_id=%d)",
+                    old_tid, best_pid, obj.tracker_id,
+                )
                 del self._tracker_to_persistent[old_tid]
             self._tracker_to_persistent[obj.tracker_id] = best_pid
             return self._update(obj, best_pid)
@@ -90,7 +95,7 @@ class SpatialObjectRegistry:
 
     def _find_nearest(self, obj: WorldObject) -> int | None:
         if not obj.class_name:
-            logger.warning(
+            logger.debug(
                 "Object tracker_id=%d has empty class_name — "
                 "proximity matching disabled to avoid false merges",
                 obj.tracker_id,

--- a/src/dino/spatial/registry.py
+++ b/src/dino/spatial/registry.py
@@ -62,6 +62,14 @@ class SpatialObjectRegistry:
                 "Proximity re-ID: tracker_id=%d -> persistent_id=%d",
                 obj.tracker_id, best_pid,
             )
+            # Clean stale tracker mapping that previously owned this persistent_id
+            old_tid = None
+            for tid, p in self._tracker_to_persistent.items():
+                if p == best_pid and tid != obj.tracker_id:
+                    old_tid = tid
+                    break
+            if old_tid is not None:
+                del self._tracker_to_persistent[old_tid]
             self._tracker_to_persistent[obj.tracker_id] = best_pid
             return self._update(obj, best_pid)
 
@@ -81,6 +89,13 @@ class SpatialObjectRegistry:
         return obj
 
     def _find_nearest(self, obj: WorldObject) -> int | None:
+        if not obj.class_name:
+            logger.warning(
+                "Object tracker_id=%d has empty class_name — "
+                "proximity matching disabled to avoid false merges",
+                obj.tracker_id,
+            )
+            return None
         best_dist = self.match_distance
         best_pid = None
         for pid, known in self._objects.items():

--- a/src/dino/zones/zone_manager.py
+++ b/src/dino/zones/zone_manager.py
@@ -78,14 +78,15 @@ class ZoneManager:
         for obj in objects:
             obj.zone_id = None
 
-        skipped_count = 0
+        # Count unregistered objects once (before zone loop to avoid N-zone inflation)
+        skipped_count = sum(1 for obj in objects if obj.persistent_id is None)
+
         for zone_id, zone_def in self._zones.items():
             state = self._states[zone_id]
             current_ids: set[int] = set()
 
             for obj in objects:
                 if obj.persistent_id is None:
-                    skipped_count += 1
                     continue
                 pos_2d = obj.world_position[:2]
                 if point_in_polygon(pos_2d, zone_def.polygon[:, :2]):

--- a/src/dino/zones/zone_manager.py
+++ b/src/dino/zones/zone_manager.py
@@ -26,7 +26,9 @@ def point_in_polygon(point: np.ndarray, polygon: np.ndarray) -> bool:
         True if point is inside the polygon.
     """
     if polygon.ndim != 2 or polygon.shape[0] < 3:
-        return False
+        raise ValueError(
+            f"polygon must be (M, 2+) with M >= 3, got shape {polygon.shape}"
+        )
     x, y = float(point[0]), float(point[1])
     n = len(polygon)
     inside = False
@@ -72,16 +74,18 @@ class ZoneManager:
         """
         new_observations: list[ZoneObservation] = []
 
+        # Reset zone assignments for this frame
+        for obj in objects:
+            obj.zone_id = None
+
+        skipped_count = 0
         for zone_id, zone_def in self._zones.items():
             state = self._states[zone_id]
             current_ids: set[int] = set()
 
             for obj in objects:
                 if obj.persistent_id is None:
-                    logger.debug(
-                        "Skipping object with tracker_id=%d: no persistent_id",
-                        obj.tracker_id,
-                    )
+                    skipped_count += 1
                     continue
                 pos_2d = obj.world_position[:2]
                 if point_in_polygon(pos_2d, zone_def.polygon[:, :2]):
@@ -123,6 +127,13 @@ class ZoneManager:
 
             state.last_observed_at = timestamp
             state.is_currently_observed = len(state.present_objects) > 0
+
+        if skipped_count > 0:
+            logger.warning(
+                "Skipped %d/%d objects with no persistent_id in frame %d. "
+                "Ensure SpatialObjectRegistry.register() is called before ZoneManager.update().",
+                skipped_count, len(objects), frame_idx,
+            )
 
         self._observations.extend(new_observations)
         return new_observations

--- a/tests/test_fixed_localizer.py
+++ b/tests/test_fixed_localizer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 import pytest
 import supervision as sv
@@ -97,3 +99,16 @@ class TestFixedCameraLocalizer:
         objects = localizer.localize(detections, frame, frame_idx=99)
 
         assert objects[0].frame_idx == 99
+
+    def test_no_tracker_id_warns_and_assigns_minus_one(self, caplog):
+        """When tracker_id is None, all objects get -1 and a warning is logged."""
+        localizer = FixedCameraLocalizer()
+        detections = sv.Detections(
+            xyxy=np.array([[10, 20, 100, 200], [0, 0, 50, 50]], dtype=np.float32),
+        )
+        frame = _make_frame()
+        with caplog.at_level(logging.WARNING):
+            objects = localizer.localize(detections, frame, frame_idx=0)
+        assert len(objects) == 2
+        assert all(obj.tracker_id == -1 for obj in objects)
+        assert "tracker_id" in caplog.text

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -147,3 +147,29 @@ class TestSpatialObjectRegistry:
         obj_c = _make_object(tracker_id=3, position=(48.0, 0.0, 0.0), timestamp=1.0)
         r_c = registry.register(obj_c)
         assert r_c.persistent_id == r_b.persistent_id
+
+    def test_empty_class_name_disables_proximity_match(self):
+        """Objects with empty class_name skip proximity matching to avoid false merges."""
+        registry = SpatialObjectRegistry(match_distance=100.0)
+        obj1 = _make_object(tracker_id=1, position=(50.0, 50.0, 0.0), class_name="", timestamp=0.0)
+        obj2 = _make_object(tracker_id=2, position=(50.0, 50.0, 0.0), class_name="", timestamp=1.0)
+        r1 = registry.register(obj1)
+        r2 = registry.register(obj2)
+        # Should NOT merge — each gets its own persistent_id
+        assert r1.persistent_id != r2.persistent_id
+
+    def test_proximity_match_cleans_old_tracker_mapping(self):
+        """When proximity re-IDs, old tracker mapping for that persistent_id is cleaned."""
+        registry = SpatialObjectRegistry(match_distance=100.0)
+        obj1 = _make_object(tracker_id=1, position=(50.0, 50.0, 0.0), timestamp=0.0)
+        r1 = registry.register(obj1)
+        pid = r1.persistent_id
+
+        # New tracker_id at same position — proximity match should re-ID
+        obj2 = _make_object(tracker_id=2, position=(52.0, 52.0, 0.0), timestamp=1.0)
+        r2 = registry.register(obj2)
+        assert r2.persistent_id == pid
+
+        # Old tracker mapping (tracker_id=1 -> pid) should be cleaned up
+        assert 1 not in registry._tracker_to_persistent
+        assert registry._tracker_to_persistent[2] == pid

--- a/tests/test_zone_manager.py
+++ b/tests/test_zone_manager.py
@@ -80,15 +80,17 @@ class TestPointInPolygon:
         assert point_in_polygon(np.array([25.0, 75.0]), polygon) is True
         assert point_in_polygon(np.array([75.0, 75.0]), polygon) is False
 
-    def test_degenerate_polygon_returns_false(self) -> None:
-        """Polygon with fewer than 3 vertices returns False."""
+    def test_degenerate_polygon_raises(self) -> None:
+        """Polygon with fewer than 3 vertices raises ValueError."""
         line = np.array([[0, 0], [100, 0]], dtype=float)
-        assert point_in_polygon(np.array([50.0, 0.0]), line) is False
+        with pytest.raises(ValueError, match="polygon"):
+            point_in_polygon(np.array([50.0, 0.0]), line)
 
-    def test_1d_polygon_returns_false(self) -> None:
-        """1D array returns False."""
+    def test_1d_polygon_raises(self) -> None:
+        """1D array raises ValueError."""
         bad = np.array([0, 0, 100])
-        assert point_in_polygon(np.array([50.0, 0.0]), bad) is False
+        with pytest.raises(ValueError, match="polygon"):
+            point_in_polygon(np.array([50.0, 0.0]), bad)
 
 
 # ===========================================================================
@@ -238,6 +240,18 @@ class TestZoneManager:
         enters = [o for o in observations if o.observation_type == ObservationType.ENTER]
         assert len(enters) == 2
         assert {e.persistent_id for e in enters} == {1, 2}
+
+    def test_zone_id_reset_across_frames(self) -> None:
+        """Zone_id is reset at start of each update, preventing stale assignments."""
+        mgr = ZoneManager(zones=[_make_square_zone()])
+        obj = _make_object(pid=1, x=50, y=50)
+        mgr.update([obj], frame_idx=0)
+        assert obj.zone_id == "zone-a"
+
+        # Move object outside — zone_id should be reset to None
+        obj_out = _make_object(pid=1, x=200, y=200)
+        mgr.update([obj_out], frame_idx=1)
+        assert obj_out.zone_id is None
 
     def test_overlapping_zones_first_zone_wins(self) -> None:
         """Object in overlapping zones gets zone_id of first matching zone."""

--- a/tests/test_zone_manager.py
+++ b/tests/test_zone_manager.py
@@ -242,16 +242,17 @@ class TestZoneManager:
         assert {e.persistent_id for e in enters} == {1, 2}
 
     def test_zone_id_reset_across_frames(self) -> None:
-        """Zone_id is reset at start of each update, preventing stale assignments."""
+        """Same object instance reused across frames gets zone_id reset."""
         mgr = ZoneManager(zones=[_make_square_zone()])
         obj = _make_object(pid=1, x=50, y=50)
         mgr.update([obj], frame_idx=0)
         assert obj.zone_id == "zone-a"
 
-        # Move object outside — zone_id should be reset to None
-        obj_out = _make_object(pid=1, x=200, y=200)
-        mgr.update([obj_out], frame_idx=1)
-        assert obj_out.zone_id is None
+        # Move the SAME object instance outside the zone
+        obj.world_position = np.array([200.0, 200.0, 0.0])
+        mgr.update([obj], frame_idx=1)
+        # Without the reset loop, obj.zone_id would still be "zone-a"
+        assert obj.zone_id is None
 
     def test_overlapping_zones_first_zone_wins(self) -> None:
         """Object in overlapping zones gets zone_id of first matching zone."""


### PR DESCRIPTION
## Summary
- **Registry identity collision fix**: Clean old tracker mapping when proximity match re-IDs an object, preventing two tracker_ids from pointing to the same persistent_id
- **Registry empty class_name guard**: Disable proximity matching for objects with empty class_name to avoid false identity merges
- **ZoneManager stale zone_id fix**: Reset `obj.zone_id` at start of each `update()` call, preventing stale zone assignments from leaking across frames
- **ZoneManager validation**: `point_in_polygon` now raises `ValueError` on invalid polygons instead of silently returning `False`
- **Logging upgrades**: `persistent_id=None` skip upgraded to WARNING with count; FixedCameraLocalizer warns when `tracker_id` is None

## Test plan
- [x] Updated degenerate polygon tests to expect `ValueError` instead of `False`
- [x] Added test for empty class_name disabling proximity match
- [x] Added test for proximity match cleaning old tracker mapping
- [x] Added test for zone_id reset across frames
- [x] Full test suite: 163 tests pass

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)