### PR TITLE
Add SpatialPipeline with end-to-end spatial video processing

### DIFF
--- a/scripts/demo_spatial.py
+++ b/scripts/demo_spatial.py
@@ -69,8 +69,8 @@ def main():
         print(f"Zones: {args.zones or 'none'}")
         print(f"Stride: {args.stride}")
 
-        def progress(frame_idx, total):
-            print(f"\rFrame {frame_idx}/{total}", end="", flush=True)
+        def progress(processed, total):
+            print(f"\rFrame {processed}/{total}", end="", flush=True)
 
         results = pipeline.run(
             args.input, output_video, json_output=json_output, progress_callback=progress

--- a/scripts/demo_spatial.py
+++ b/scripts/demo_spatial.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""CLI entry point for the spatial video processing pipeline."""
+
+import argparse
+import sys
+import traceback
+from pathlib import Path
+
+from dino.config import PipelineConfig, SpatialConfig
+from dino.detectors.grounding_dino import GroundingDINODetector
+from dino.spatial.spatial_pipeline import SpatialPipeline
+
+
+def main():
+    parser = argparse.ArgumentParser(description="DINO Spatial Pipeline Demo")
+    parser.add_argument("--input", required=True, help="Input video path")
+    parser.add_argument("--output", required=True, help="Output directory")
+    parser.add_argument("--zones", default=None, help="Path to zones.json")
+    parser.add_argument(
+        "--prompts", nargs="+", required=True, help="Text prompts for detection"
+    )
+    parser.add_argument(
+        "--camera-mode", default="fixed", choices=["fixed"], help="Camera mode"
+    )
+    parser.add_argument(
+        "--stride", type=int, default=1, help="Process every Nth frame"
+    )
+    parser.add_argument(
+        "--threshold", type=float, default=0.3, help="Box confidence threshold"
+    )
+    parser.add_argument("--device", default=None, help="Device (cuda/mps/cpu)")
+    args = parser.parse_args()
+
+    try:
+        if not Path(args.input).exists():
+            print(f"Error: input video not found: {args.input}", file=sys.stderr)
+            sys.exit(1)
+
+        output_dir = Path(args.output)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        config = PipelineConfig(
+            prompts=args.prompts,
+            stride=args.stride,
+        )
+
+        spatial_config = SpatialConfig(
+            camera_mode=args.camera_mode,
+            zones_path=args.zones,
+        )
+
+        print("Loading Grounding DINO...")
+        detector = GroundingDINODetector(
+            box_threshold=args.threshold,
+            device=args.device,
+        )
+        print(f"Device: {detector.device}")
+
+        pipeline = SpatialPipeline(
+            detector=detector, config=config, spatial_config=spatial_config
+        )
+
+        output_video = str(output_dir / "spatial_annotated.mp4")
+        json_output = str(output_dir / "spatial_results.json")
+
+        print(f"Processing: {args.input}")
+        print(f"Output video: {output_video}")
+        print(f"Output JSON: {json_output}")
+        print(f"Zones: {args.zones or 'none'}")
+        print(f"Stride: {args.stride}")
+
+        def progress(frame_idx, total):
+            print(f"\rFrame {frame_idx}/{total}", end="", flush=True)
+
+        results = pipeline.run(
+            args.input, output_video, json_output=json_output, progress_callback=progress
+        )
+
+        print(f"\n\nDone! Processed {len(results.frame_results)} frames.")
+        print(f"  Observations: {len(results.observations)}")
+        print(f"  Events: {len(results.events)}")
+
+    except KeyboardInterrupt:
+        print("\nInterrupted.", file=sys.stderr)
+        sys.exit(130)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except (RuntimeError, ValueError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception:
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dino/annotation/zone_annotator.py
+++ b/src/dino/annotation/zone_annotator.py
@@ -47,8 +47,6 @@ class ZoneAnnotator:
         if not zones:
             return annotated
 
-        overlay = annotated.copy()
-
         for zone in zones:
             polygon_pts = zone.polygon[:, :2].astype(np.int32)
 
@@ -62,26 +60,23 @@ class ZoneAnnotator:
 
             color = self.active_color if is_active else self.zone_color
 
-            # Fill polygon on overlay
-            cv2.fillPoly(overlay, [polygon_pts], color)
-
-            # Blend overlay with annotated frame
-            annotated = cv2.addWeighted(overlay, self.alpha, annotated, 1 - self.alpha, 0)
-            # Reset overlay for next zone
+            # Fill polygon on fresh overlay, then blend
             overlay = annotated.copy()
+            cv2.fillPoly(overlay, [polygon_pts], color)
+            annotated = cv2.addWeighted(overlay, self.alpha, annotated, 1 - self.alpha, 0)
 
             # Draw outline
             cv2.polylines(annotated, [polygon_pts], isClosed=True, color=color, thickness=2)
 
             # Draw label
-            centroid = polygon_pts.mean(axis=0).astype(int)
+            centroid = tuple(int(v) for v in polygon_pts.mean(axis=0))
             label = zone.name
             if is_active:
                 label += f" ({object_count})"
             cv2.putText(
                 annotated,
                 label,
-                tuple(centroid),
+                centroid,
                 cv2.FONT_HERSHEY_SIMPLEX,
                 0.6,
                 color,

--- a/src/dino/annotation/zone_annotator.py
+++ b/src/dino/annotation/zone_annotator.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+
+from dino.zones.models import ZoneDefinition, ZoneState
+
+
+class ZoneAnnotator:
+    """Annotator that draws zone polygons on video frames.
+
+    Active zones (containing objects) are drawn in active_color,
+    inactive zones in zone_color. Zones are drawn as semi-transparent
+    filled polygons with solid outlines and text labels.
+    """
+
+    def __init__(
+        self,
+        zone_color: tuple[int, int, int] = (0, 255, 0),
+        active_color: tuple[int, int, int] = (0, 165, 255),
+        alpha: float = 0.2,
+    ):
+        self.zone_color = zone_color
+        self.active_color = active_color
+        self.alpha = alpha
+
+    def annotate(
+        self,
+        frame: np.ndarray,
+        zones: list[ZoneDefinition],
+        zone_states: dict[str, ZoneState] | None = None,
+    ) -> np.ndarray:
+        """Draw zone overlays on a frame.
+
+        Args:
+            frame: BGR image (H, W, 3)
+            zones: Zone definitions to draw
+            zone_states: Optional mapping of zone_id -> ZoneState.
+                Zones with present_objects are drawn as active.
+
+        Returns:
+            Annotated copy of the frame (input is not modified).
+        """
+        annotated = frame.copy()
+        if not zones:
+            return annotated
+
+        overlay = annotated.copy()
+
+        for zone in zones:
+            polygon_pts = zone.polygon[:, :2].astype(np.int32)
+
+            # Determine if zone is active
+            is_active = False
+            object_count = 0
+            if zone_states and zone.zone_id in zone_states:
+                state = zone_states[zone.zone_id]
+                object_count = len(state.present_objects)
+                is_active = object_count > 0
+
+            color = self.active_color if is_active else self.zone_color
+
+            # Fill polygon on overlay
+            cv2.fillPoly(overlay, [polygon_pts], color)
+
+            # Blend overlay with annotated frame
+            cv2.addWeighted(overlay, self.alpha, annotated, 1 - self.alpha, 0, annotated)
+            # Reset overlay for next zone
+            overlay = annotated.copy()
+
+            # Draw outline
+            cv2.polylines(annotated, [polygon_pts], isClosed=True, color=color, thickness=2)
+
+            # Draw label
+            centroid = polygon_pts.mean(axis=0).astype(int)
+            label = zone.name
+            if is_active:
+                label += f" ({object_count})"
+            cv2.putText(
+                annotated,
+                label,
+                tuple(centroid),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.6,
+                color,
+                2,
+            )
+
+        return annotated

--- a/src/dino/annotation/zone_annotator.py
+++ b/src/dino/annotation/zone_annotator.py
@@ -66,7 +66,7 @@ class ZoneAnnotator:
             cv2.fillPoly(overlay, [polygon_pts], color)
 
             # Blend overlay with annotated frame
-            cv2.addWeighted(overlay, self.alpha, annotated, 1 - self.alpha, 0, annotated)
+            annotated = cv2.addWeighted(overlay, self.alpha, annotated, 1 - self.alpha, 0)
             # Reset overlay for next zone
             overlay = annotated.copy()
 

--- a/src/dino/annotation/zone_annotator.py
+++ b/src/dino/annotation/zone_annotator.py
@@ -20,6 +20,8 @@ class ZoneAnnotator:
         active_color: tuple[int, int, int] = (0, 165, 255),
         alpha: float = 0.2,
     ):
+        if not 0.0 <= alpha <= 1.0:
+            raise ValueError(f"alpha must be in [0, 1], got {alpha}")
         self.zone_color = zone_color
         self.active_color = active_color
         self.alpha = alpha

--- a/src/dino/config.py
+++ b/src/dino/config.py
@@ -18,3 +18,25 @@ class PipelineConfig:
             raise ValueError("prompts must not be empty")
         if self.stride < 1:
             raise ValueError(f"stride must be >= 1, got {self.stride}")
+
+
+@dataclass
+class SpatialConfig:
+    """Configuration for spatial processing."""
+
+    camera_mode: str = "fixed"
+    match_distance: float = 50.0
+    max_age_seconds: float = 30.0
+    zones_path: str | None = None
+    rules: list[dict] | None = None
+
+    def __post_init__(self):
+        if self.camera_mode not in ("fixed",):
+            raise ValueError(
+                f"Unsupported camera_mode: {self.camera_mode!r}, "
+                f"must be one of ('fixed',)"
+            )
+        if self.match_distance <= 0:
+            raise ValueError(f"match_distance must be > 0, got {self.match_distance}")
+        if self.max_age_seconds <= 0:
+            raise ValueError(f"max_age_seconds must be > 0, got {self.max_age_seconds}")

--- a/src/dino/config.py
+++ b/src/dino/config.py
@@ -40,3 +40,9 @@ class SpatialConfig:
             raise ValueError(f"match_distance must be > 0, got {self.match_distance}")
         if self.max_age_seconds <= 0:
             raise ValueError(f"max_age_seconds must be > 0, got {self.max_age_seconds}")
+        if self.rules is not None:
+            for i, r in enumerate(self.rules):
+                if not isinstance(r, dict):
+                    raise ValueError(f"rules[{i}] must be a dict, got {type(r).__name__}")
+                if "event_type" not in r:
+                    raise ValueError(f"rules[{i}] missing required key 'event_type'")

--- a/src/dino/spatial/__init__.py
+++ b/src/dino/spatial/__init__.py
@@ -1,0 +1,11 @@
+def __getattr__(name):
+    if name in ("SpatialPipeline", "SpatialResults"):
+        from dino.spatial.spatial_pipeline import SpatialPipeline, SpatialResults
+
+        globals()["SpatialPipeline"] = SpatialPipeline
+        globals()["SpatialResults"] = SpatialResults
+        return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = ["SpatialPipeline", "SpatialResults"]

--- a/src/dino/spatial/spatial_pipeline.py
+++ b/src/dino/spatial/spatial_pipeline.py
@@ -6,7 +6,6 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import cv2
 import numpy as np
 import supervision as sv
 
@@ -15,11 +14,12 @@ from dino.annotation.zone_annotator import ZoneAnnotator
 from dino.config import PipelineConfig, SpatialConfig
 from dino.detectors.base import BaseDetector
 from dino.spatial.fixed_camera_localizer import FixedCameraLocalizer
+from dino.spatial.models import WorldObject
 from dino.spatial.registry import SpatialObjectRegistry
 from dino.tracking.tracker import ObjectTracker
 from dino.zones.event_rules import EventRule, RuleEngine
 from dino.zones.loader import load_zones_file
-from dino.zones.models import ZoneDefinition
+from dino.zones.models import ZoneDefinition, ZoneEvent, ZoneObservation
 from dino.zones.zone_manager import ZoneManager
 
 logger = logging.getLogger(__name__)
@@ -51,48 +51,61 @@ class SpatialPipeline:
         self.config = config
         self.spatial_config = spatial_config
 
-        self.tracker = ObjectTracker(
+        self._tracker = ObjectTracker(
             track_activation_threshold=config.track_activation_threshold,
             lost_track_buffer=config.lost_track_buffer,
         )
-        self.annotator = FrameAnnotator(trace_length=config.trace_length)
-        self.zone_annotator = ZoneAnnotator()
+        self._annotator = FrameAnnotator(trace_length=config.trace_length)
+        self._zone_annotator = ZoneAnnotator()
 
         # Localizer
         if spatial_config.camera_mode == "fixed":
-            self.localizer = FixedCameraLocalizer()
+            self._localizer = FixedCameraLocalizer()
         else:
             raise ValueError(f"Unsupported camera_mode: {spatial_config.camera_mode!r}")
 
-        self.registry = SpatialObjectRegistry(
+        self._registry = SpatialObjectRegistry(
             match_distance=spatial_config.match_distance,
             max_age_seconds=spatial_config.max_age_seconds,
         )
 
         # Load zones and rules
-        self.zones: list[ZoneDefinition] = []
+        self._zones: list[ZoneDefinition] = []
         rules: list[EventRule] = []
 
         if spatial_config.zones_path:
-            self.zones, file_rules = load_zones_file(spatial_config.zones_path)
+            self._zones, file_rules = load_zones_file(spatial_config.zones_path)
             rules = file_rules
 
         # Inline rules override file rules
         if spatial_config.rules:
-            rules = [
-                EventRule(
-                    event_type=r["event_type"],
-                    requires_all=r.get("requires_all"),
-                    requires_any=r.get("requires_any"),
-                    requires_none=r.get("requires_none"),
-                    min_count=r.get("min_count"),
-                    hysteresis=r.get("hysteresis", 1),
+            if rules:
+                logger.warning(
+                    "Inline rules override %d rules from zones file", len(rules)
                 )
-                for r in spatial_config.rules
-            ]
+            rules = []
+            for i, r in enumerate(spatial_config.rules):
+                if "event_type" not in r:
+                    raise ValueError(
+                        f"Inline rule at index {i} is missing required key 'event_type'"
+                    )
+                try:
+                    rules.append(EventRule(
+                        event_type=r["event_type"],
+                        requires_all=r.get("requires_all"),
+                        requires_any=r.get("requires_any"),
+                        requires_none=r.get("requires_none"),
+                        min_count=r.get("min_count"),
+                        hysteresis=r.get("hysteresis", 1),
+                    ))
+                except (ValueError, TypeError) as e:
+                    raise ValueError(
+                        f"Invalid inline rule at index {i} "
+                        f"(event_type={r.get('event_type', '?')}): {e}"
+                    ) from e
 
-        self.zone_manager = ZoneManager(zones=self.zones if self.zones else None)
-        self.rule_engine = RuleEngine(rules=rules)
+        self._zone_manager = ZoneManager(zones=self._zones if self._zones else None)
+        self._rule_engine = RuleEngine(rules=rules)
 
     def run(
         self,
@@ -107,7 +120,7 @@ class SpatialPipeline:
             input_path: Path to input video.
             output_path: Path for annotated output video.
             json_output: Optional path to export spatial results as JSON.
-            progress_callback: Optional callback(frame_idx, total_frames).
+            progress_callback: Optional callback(processed_count, total_frames).
 
         Returns:
             SpatialResults with per-frame data, observations, and events.
@@ -122,20 +135,21 @@ class SpatialPipeline:
         video_info = sv.VideoInfo.from_video_path(input_path)
         adjusted_fps = (
             video_info.fps / self.config.stride
-            if self.config.stride > 1
+            if self.config.stride > 1 and video_info.fps > 0
             else video_info.fps
         )
+        total_frames = max(1, video_info.total_frames // self.config.stride)
         output_info = sv.VideoInfo(
             width=video_info.width,
             height=video_info.height,
             fps=adjusted_fps,
-            total_frames=video_info.total_frames,
+            total_frames=total_frames,
         )
 
         frame_generator = sv.get_video_frames_generator(input_path)
-        total_frames = max(1, video_info.total_frames // self.config.stride)
 
         results = SpatialResults()
+        processed = 0
 
         with sv.VideoSink(output_path, output_info) as sink:
             for frame_idx, frame in enumerate(frame_generator):
@@ -143,17 +157,25 @@ class SpatialPipeline:
                     continue
 
                 timestamp = frame_idx / video_info.fps if video_info.fps > 0 else 0.0
-                frame_result = self._process_frame(
-                    frame, frame_idx, timestamp, sink
-                )
+
+                try:
+                    frame_result = self._process_frame(
+                        frame, frame_idx, timestamp, sink
+                    )
+                except Exception as e:
+                    raise RuntimeError(
+                        f"Error processing frame {frame_idx}: {e}"
+                    ) from e
+
                 results.frame_results.append(frame_result)
 
                 # Accumulate observations and events
                 results.observations.extend(frame_result.get("observations", []))
                 results.events.extend(frame_result.get("events", []))
 
+                processed += 1
                 if progress_callback is not None:
-                    progress_callback(frame_idx, total_frames)
+                    progress_callback(processed, total_frames)
 
         if json_output:
             Path(json_output).parent.mkdir(parents=True, exist_ok=True)
@@ -178,14 +200,16 @@ class SpatialPipeline:
         sink: sv.VideoSink,
     ) -> dict:
         """Process a single frame through the full spatial pipeline."""
+        logger.debug("Processing frame %d (t=%.3f)", frame_idx, timestamp)
+
         # Detect
         detections = self.detector.detect(frame, self.config.prompts)
 
         # Track
-        detections = self.tracker.update(detections)
+        detections = self._tracker.update(detections)
 
         # Localize
-        world_objects = self.localizer.localize(detections, frame, frame_idx)
+        world_objects = self._localizer.localize(detections, frame, frame_idx)
 
         # Set timestamp on all objects
         for obj in world_objects:
@@ -193,33 +217,38 @@ class SpatialPipeline:
 
         # Register (persistent identity)
         for i, obj in enumerate(world_objects):
-            world_objects[i] = self.registry.register(obj)
+            world_objects[i] = self._registry.register(obj)
 
         # Zone update
-        observations = self.zone_manager.update(world_objects, frame_idx, timestamp)
+        observations = self._zone_manager.update(world_objects, frame_idx, timestamp)
 
         # Rule evaluation
-        events = []
-        for zone in self.zones:
-            state = self.zone_manager.get_zone_state(zone.zone_id)
+        events: list[ZoneEvent] = []
+        for zone in self._zones:
+            state = self._zone_manager.get_zone_state(zone.zone_id)
             if state is not None:
-                zone_events = self.rule_engine.evaluate(state, frame_idx, timestamp)
+                zone_events = self._rule_engine.evaluate(state, frame_idx, timestamp)
                 events.extend(zone_events)
 
         # Annotate: base (boxes/labels/traces)
-        annotated = self.annotator.annotate(frame, detections)
+        annotated = self._annotator.annotate(frame, detections)
 
         # Annotate: zones
-        if self.zones:
+        if self._zones:
             zone_states = {}
-            for zone in self.zones:
-                state = self.zone_manager.get_zone_state(zone.zone_id)
+            for zone in self._zones:
+                state = self._zone_manager.get_zone_state(zone.zone_id)
                 if state is not None:
                     zone_states[zone.zone_id] = state
-            annotated = self.zone_annotator.annotate(annotated, self.zones, zone_states)
+            annotated = self._zone_annotator.annotate(annotated, self._zones, zone_states)
 
         # Write to sink
         sink.write_frame(annotated)
+
+        logger.debug(
+            "Frame %d: %d objects, %d observations, %d events",
+            frame_idx, len(world_objects), len(observations), len(events),
+        )
 
         return self._build_frame_result(
             frame_idx, timestamp, world_objects, observations, events
@@ -229,9 +258,9 @@ class SpatialPipeline:
     def _build_frame_result(
         frame_idx: int,
         timestamp: float,
-        objects: list,
-        observations: list,
-        events: list,
+        objects: list[WorldObject],
+        observations: list[ZoneObservation],
+        events: list[ZoneEvent],
     ) -> dict:
         return {
             "frame_idx": frame_idx,
@@ -255,7 +284,7 @@ class SpatialPipeline:
         }
 
     @staticmethod
-    def _observation_to_dict(obs) -> dict:
+    def _observation_to_dict(obs: ZoneObservation) -> dict:
         return {
             "zone_id": obs.zone_id,
             "persistent_id": obs.persistent_id,
@@ -265,7 +294,7 @@ class SpatialPipeline:
         }
 
     @staticmethod
-    def _event_to_dict(event) -> dict:
+    def _event_to_dict(event: ZoneEvent) -> dict:
         return {
             "zone_id": event.zone_id,
             "event_type": event.event_type,

--- a/src/dino/spatial/spatial_pipeline.py
+++ b/src/dino/spatial/spatial_pipeline.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -140,10 +141,10 @@ class SpatialPipeline:
             )
         adjusted_fps = (
             video_info.fps / self.config.stride
-            if self.config.stride > 1 and video_info.fps > 0
+            if self.config.stride > 1
             else video_info.fps
         )
-        total_frames = max(1, video_info.total_frames // self.config.stride)
+        total_frames = max(1, math.ceil(video_info.total_frames / self.config.stride))
         output_info = sv.VideoInfo(
             width=video_info.width,
             height=video_info.height,
@@ -207,9 +208,11 @@ class SpatialPipeline:
                     )
                 tmp_path.replace(json_path)
             except (TypeError, OSError) as e:
-                logger.error("Failed to write JSON results to %s: %s", json_output, e)
                 if tmp_path.exists():
                     tmp_path.unlink()
+                raise RuntimeError(
+                    f"Failed to write JSON results to {json_output}: {e}"
+                ) from e
 
         return results
 

--- a/src/dino/spatial/spatial_pipeline.py
+++ b/src/dino/spatial/spatial_pipeline.py
@@ -133,6 +133,10 @@ class SpatialPipeline:
         output_p.parent.mkdir(parents=True, exist_ok=True)
 
         video_info = sv.VideoInfo.from_video_path(input_path)
+        if video_info.fps <= 0:
+            logger.warning(
+                "Video reports fps=%s; timestamps will all be 0.0", video_info.fps
+            )
         adjusted_fps = (
             video_info.fps / self.config.stride
             if self.config.stride > 1 and video_info.fps > 0
@@ -175,11 +179,18 @@ class SpatialPipeline:
 
                 processed += 1
                 if progress_callback is not None:
-                    progress_callback(processed, total_frames)
+                    try:
+                        progress_callback(processed, total_frames)
+                    except Exception:
+                        logger.warning(
+                            "progress_callback raised an exception", exc_info=True
+                        )
 
         if json_output:
-            Path(json_output).parent.mkdir(parents=True, exist_ok=True)
-            with open(json_output, "w") as f:
+            json_path = Path(json_output)
+            json_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = json_path.with_suffix(".json.tmp")
+            with open(tmp_path, "w") as f:
                 json.dump(
                     {
                         "frames": results.frame_results,
@@ -189,6 +200,7 @@ class SpatialPipeline:
                     f,
                     indent=2,
                 )
+            tmp_path.replace(json_path)
 
         return results
 

--- a/src/dino/spatial/spatial_pipeline.py
+++ b/src/dino/spatial/spatial_pipeline.py
@@ -134,8 +134,9 @@ class SpatialPipeline:
 
         video_info = sv.VideoInfo.from_video_path(input_path)
         if video_info.fps <= 0:
-            logger.warning(
-                "Video reports fps=%s; timestamps will all be 0.0", video_info.fps
+            raise ValueError(
+                f"Input video reports fps={video_info.fps}. "
+                f"A positive FPS is required for correct timestamps and output video."
             )
         adjusted_fps = (
             video_info.fps / self.config.stride
@@ -182,25 +183,33 @@ class SpatialPipeline:
                     try:
                         progress_callback(processed, total_frames)
                     except Exception:
-                        logger.warning(
-                            "progress_callback raised an exception", exc_info=True
+                        logger.error(
+                            "progress_callback raised an exception; "
+                            "disabling further callbacks for this run",
+                            exc_info=True,
                         )
+                        progress_callback = None
 
         if json_output:
             json_path = Path(json_output)
             json_path.parent.mkdir(parents=True, exist_ok=True)
             tmp_path = json_path.with_suffix(".json.tmp")
-            with open(tmp_path, "w") as f:
-                json.dump(
-                    {
-                        "frames": results.frame_results,
-                        "observations": results.observations,
-                        "events": results.events,
-                    },
-                    f,
-                    indent=2,
-                )
-            tmp_path.replace(json_path)
+            try:
+                with open(tmp_path, "w") as f:
+                    json.dump(
+                        {
+                            "frames": results.frame_results,
+                            "observations": results.observations,
+                            "events": results.events,
+                        },
+                        f,
+                        indent=2,
+                    )
+                tmp_path.replace(json_path)
+            except (TypeError, OSError) as e:
+                logger.error("Failed to write JSON results to %s: %s", json_output, e)
+                if tmp_path.exists():
+                    tmp_path.unlink()
 
         return results
 

--- a/src/dino/spatial/spatial_pipeline.py
+++ b/src/dino/spatial/spatial_pipeline.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import cv2
+import numpy as np
+import supervision as sv
+
+from dino.annotation.annotator import FrameAnnotator
+from dino.annotation.zone_annotator import ZoneAnnotator
+from dino.config import PipelineConfig, SpatialConfig
+from dino.detectors.base import BaseDetector
+from dino.spatial.fixed_camera_localizer import FixedCameraLocalizer
+from dino.spatial.registry import SpatialObjectRegistry
+from dino.tracking.tracker import ObjectTracker
+from dino.zones.event_rules import EventRule, RuleEngine
+from dino.zones.loader import load_zones_file
+from dino.zones.models import ZoneDefinition
+from dino.zones.zone_manager import ZoneManager
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SpatialResults:
+    """Results from a spatial pipeline run."""
+
+    frame_results: list[dict] = field(default_factory=list)
+    observations: list[dict] = field(default_factory=list)
+    events: list[dict] = field(default_factory=list)
+
+
+class SpatialPipeline:
+    """End-to-end spatial video processing pipeline.
+
+    detect -> track -> localize -> register -> zone update ->
+    rule eval -> annotate -> export
+    """
+
+    def __init__(
+        self,
+        detector: BaseDetector,
+        config: PipelineConfig,
+        spatial_config: SpatialConfig,
+    ):
+        self.detector = detector
+        self.config = config
+        self.spatial_config = spatial_config
+
+        self.tracker = ObjectTracker(
+            track_activation_threshold=config.track_activation_threshold,
+            lost_track_buffer=config.lost_track_buffer,
+        )
+        self.annotator = FrameAnnotator(trace_length=config.trace_length)
+        self.zone_annotator = ZoneAnnotator()
+
+        # Localizer
+        if spatial_config.camera_mode == "fixed":
+            self.localizer = FixedCameraLocalizer()
+        else:
+            raise ValueError(f"Unsupported camera_mode: {spatial_config.camera_mode!r}")
+
+        self.registry = SpatialObjectRegistry(
+            match_distance=spatial_config.match_distance,
+            max_age_seconds=spatial_config.max_age_seconds,
+        )
+
+        # Load zones and rules
+        self.zones: list[ZoneDefinition] = []
+        rules: list[EventRule] = []
+
+        if spatial_config.zones_path:
+            self.zones, file_rules = load_zones_file(spatial_config.zones_path)
+            rules = file_rules
+
+        # Inline rules override file rules
+        if spatial_config.rules:
+            rules = [
+                EventRule(
+                    event_type=r["event_type"],
+                    requires_all=r.get("requires_all"),
+                    requires_any=r.get("requires_any"),
+                    requires_none=r.get("requires_none"),
+                    min_count=r.get("min_count"),
+                    hysteresis=r.get("hysteresis", 1),
+                )
+                for r in spatial_config.rules
+            ]
+
+        self.zone_manager = ZoneManager(zones=self.zones if self.zones else None)
+        self.rule_engine = RuleEngine(rules=rules)
+
+    def run(
+        self,
+        input_path: str,
+        output_path: str,
+        json_output: str | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> SpatialResults:
+        """Process a video file with full spatial pipeline.
+
+        Args:
+            input_path: Path to input video.
+            output_path: Path for annotated output video.
+            json_output: Optional path to export spatial results as JSON.
+            progress_callback: Optional callback(frame_idx, total_frames).
+
+        Returns:
+            SpatialResults with per-frame data, observations, and events.
+        """
+        input_p = Path(input_path)
+        if not input_p.exists():
+            raise FileNotFoundError(f"Input video not found: {input_path}")
+
+        output_p = Path(output_path)
+        output_p.parent.mkdir(parents=True, exist_ok=True)
+
+        video_info = sv.VideoInfo.from_video_path(input_path)
+        adjusted_fps = (
+            video_info.fps / self.config.stride
+            if self.config.stride > 1
+            else video_info.fps
+        )
+        output_info = sv.VideoInfo(
+            width=video_info.width,
+            height=video_info.height,
+            fps=adjusted_fps,
+            total_frames=video_info.total_frames,
+        )
+
+        frame_generator = sv.get_video_frames_generator(input_path)
+        total_frames = max(1, video_info.total_frames // self.config.stride)
+
+        results = SpatialResults()
+
+        with sv.VideoSink(output_path, output_info) as sink:
+            for frame_idx, frame in enumerate(frame_generator):
+                if frame_idx % self.config.stride != 0:
+                    continue
+
+                timestamp = frame_idx / video_info.fps if video_info.fps > 0 else 0.0
+                frame_result = self._process_frame(
+                    frame, frame_idx, timestamp, sink
+                )
+                results.frame_results.append(frame_result)
+
+                # Accumulate observations and events
+                results.observations.extend(frame_result.get("observations", []))
+                results.events.extend(frame_result.get("events", []))
+
+                if progress_callback is not None:
+                    progress_callback(frame_idx, total_frames)
+
+        if json_output:
+            Path(json_output).parent.mkdir(parents=True, exist_ok=True)
+            with open(json_output, "w") as f:
+                json.dump(
+                    {
+                        "frames": results.frame_results,
+                        "observations": results.observations,
+                        "events": results.events,
+                    },
+                    f,
+                    indent=2,
+                )
+
+        return results
+
+    def _process_frame(
+        self,
+        frame: np.ndarray,
+        frame_idx: int,
+        timestamp: float,
+        sink: sv.VideoSink,
+    ) -> dict:
+        """Process a single frame through the full spatial pipeline."""
+        # Detect
+        detections = self.detector.detect(frame, self.config.prompts)
+
+        # Track
+        detections = self.tracker.update(detections)
+
+        # Localize
+        world_objects = self.localizer.localize(detections, frame, frame_idx)
+
+        # Set timestamp on all objects
+        for obj in world_objects:
+            obj.timestamp = timestamp
+
+        # Register (persistent identity)
+        for i, obj in enumerate(world_objects):
+            world_objects[i] = self.registry.register(obj)
+
+        # Zone update
+        observations = self.zone_manager.update(world_objects, frame_idx, timestamp)
+
+        # Rule evaluation
+        events = []
+        for zone in self.zones:
+            state = self.zone_manager.get_zone_state(zone.zone_id)
+            if state is not None:
+                zone_events = self.rule_engine.evaluate(state, frame_idx, timestamp)
+                events.extend(zone_events)
+
+        # Annotate: base (boxes/labels/traces)
+        annotated = self.annotator.annotate(frame, detections)
+
+        # Annotate: zones
+        if self.zones:
+            zone_states = {}
+            for zone in self.zones:
+                state = self.zone_manager.get_zone_state(zone.zone_id)
+                if state is not None:
+                    zone_states[zone.zone_id] = state
+            annotated = self.zone_annotator.annotate(annotated, self.zones, zone_states)
+
+        # Write to sink
+        sink.write_frame(annotated)
+
+        return self._build_frame_result(
+            frame_idx, timestamp, world_objects, observations, events
+        )
+
+    @staticmethod
+    def _build_frame_result(
+        frame_idx: int,
+        timestamp: float,
+        objects: list,
+        observations: list,
+        events: list,
+    ) -> dict:
+        return {
+            "frame_idx": frame_idx,
+            "timestamp": timestamp,
+            "objects": [
+                {
+                    "persistent_id": obj.persistent_id,
+                    "tracker_id": obj.tracker_id,
+                    "class_name": obj.class_name,
+                    "confidence": obj.confidence,
+                    "bbox": obj.bbox_xyxy.tolist(),
+                    "world_position": obj.world_position.tolist(),
+                    "zone_id": obj.zone_id,
+                }
+                for obj in objects
+            ],
+            "observations": [
+                SpatialPipeline._observation_to_dict(obs) for obs in observations
+            ],
+            "events": [SpatialPipeline._event_to_dict(e) for e in events],
+        }
+
+    @staticmethod
+    def _observation_to_dict(obs) -> dict:
+        return {
+            "zone_id": obs.zone_id,
+            "persistent_id": obs.persistent_id,
+            "observation_type": obs.observation_type.value,
+            "frame_idx": obs.frame_idx,
+            "timestamp": obs.timestamp,
+        }
+
+    @staticmethod
+    def _event_to_dict(event) -> dict:
+        return {
+            "zone_id": event.zone_id,
+            "event_type": event.event_type,
+            "frame_idx": event.frame_idx,
+            "timestamp": event.timestamp,
+            "details": dict(event.details) if event.details else {},
+        }

--- a/src/dino/zones/loader.py
+++ b/src/dino/zones/loader.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+from dino.zones.models import ZoneDefinition
+from dino.zones.event_rules import EventRule
+
+
+def load_zones_file(path: str | Path) -> tuple[list[ZoneDefinition], list[EventRule]]:
+    """Load zone definitions and event rules from a JSON file.
+
+    JSON format:
+    {
+        "zones": [
+            {"zone_id": "z1", "name": "Zone 1", "polygon": [[0,0],[100,0],[100,100],[0,100]]},
+            ...
+        ],
+        "rules": [
+            {"event_type": "occupied", "requires_any": ["person"]},
+            ...
+        ]
+    }
+
+    Raises:
+        FileNotFoundError: If path does not exist.
+        ValueError: If JSON is missing required "zones" key.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Zones file not found: {path}")
+
+    data = json.loads(path.read_text())
+
+    if "zones" not in data:
+        raise ValueError("Zones file must contain a 'zones' key")
+
+    zones = []
+    for z in data["zones"]:
+        zones.append(ZoneDefinition(
+            zone_id=z["zone_id"],
+            name=z["name"],
+            polygon=np.array(z["polygon"], dtype=np.float64),
+            metadata=z.get("metadata", {}),
+        ))
+
+    rules = []
+    for r in data.get("rules", []):
+        rules.append(EventRule(
+            event_type=r["event_type"],
+            requires_all=r.get("requires_all"),
+            requires_any=r.get("requires_any"),
+            requires_none=r.get("requires_none"),
+            min_count=r.get("min_count"),
+            hysteresis=r.get("hysteresis", 1),
+        ))
+
+    return zones, rules

--- a/src/dino/zones/loader.py
+++ b/src/dino/zones/loader.py
@@ -26,35 +26,60 @@ def load_zones_file(path: str | Path) -> tuple[list[ZoneDefinition], list[EventR
 
     Raises:
         FileNotFoundError: If path does not exist.
-        ValueError: If JSON is missing required "zones" key.
+        ValueError: If JSON is invalid or missing required keys.
     """
     path = Path(path)
     if not path.exists():
         raise FileNotFoundError(f"Zones file not found: {path}")
 
-    data = json.loads(path.read_text())
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Zones file {path} contains invalid JSON: {e}") from e
 
     if "zones" not in data:
         raise ValueError("Zones file must contain a 'zones' key")
 
     zones = []
-    for z in data["zones"]:
-        zones.append(ZoneDefinition(
-            zone_id=z["zone_id"],
-            name=z["name"],
-            polygon=np.array(z["polygon"], dtype=np.float64),
-            metadata=z.get("metadata", {}),
-        ))
+    for i, z in enumerate(data["zones"]):
+        required = ("zone_id", "name", "polygon")
+        missing = [k for k in required if k not in z]
+        if missing:
+            raise ValueError(
+                f"Zone entry {i} in {path} is missing required keys: {missing}"
+            )
+        try:
+            zones.append(ZoneDefinition(
+                zone_id=z["zone_id"],
+                name=z["name"],
+                polygon=np.array(z["polygon"], dtype=np.float64),
+                metadata=z.get("metadata", {}),
+            ))
+        except (ValueError, TypeError) as e:
+            raise ValueError(
+                f"Invalid zone entry {i} (zone_id={z.get('zone_id', '?')}) "
+                f"in {path}: {e}"
+            ) from e
 
     rules = []
-    for r in data.get("rules", []):
-        rules.append(EventRule(
-            event_type=r["event_type"],
-            requires_all=r.get("requires_all"),
-            requires_any=r.get("requires_any"),
-            requires_none=r.get("requires_none"),
-            min_count=r.get("min_count"),
-            hysteresis=r.get("hysteresis", 1),
-        ))
+    for i, r in enumerate(data.get("rules", [])):
+        if "event_type" not in r:
+            raise ValueError(
+                f"Rule entry {i} in {path} is missing required key 'event_type'"
+            )
+        try:
+            rules.append(EventRule(
+                event_type=r["event_type"],
+                requires_all=r.get("requires_all"),
+                requires_any=r.get("requires_any"),
+                requires_none=r.get("requires_none"),
+                min_count=r.get("min_count"),
+                hysteresis=r.get("hysteresis", 1),
+            ))
+        except (ValueError, TypeError) as e:
+            raise ValueError(
+                f"Invalid rule entry {i} (event_type={r.get('event_type', '?')}) "
+                f"in {path}: {e}"
+            ) from e
 
     return zones, rules

--- a/tests/test_spatial_pipeline.py
+++ b/tests/test_spatial_pipeline.py
@@ -480,3 +480,39 @@ class TestSpatialPipeline:
         event_types = [e["event_type"] for e in results.events]
         assert "inline_rule" in event_types
         assert "file_rule" not in event_types
+
+    def test_progress_callback_exception_does_not_kill_pipeline(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        _make_test_video(input_path, num_frames=3)
+
+        def bad_callback(p, t):
+            raise RuntimeError("callback boom")
+
+        detector = self._make_mock_detector()
+        config = PipelineConfig(prompts=["person"])
+        spatial_config = SpatialConfig()
+        pipeline = SpatialPipeline(detector, config, spatial_config)
+        # Should complete without raising
+        results = pipeline.run(input_path, output_path, progress_callback=bad_callback)
+        assert len(results.frame_results) == 3
+
+    def test_json_export_atomic_no_partial_file(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        json_path = str(tmp_path / "results.json")
+        _make_test_video(input_path, num_frames=3)
+
+        detector = self._make_mock_detector()
+        config = PipelineConfig(prompts=["person"])
+        spatial_config = SpatialConfig()
+        pipeline = SpatialPipeline(detector, config, spatial_config)
+        pipeline.run(input_path, output_path, json_output=json_path)
+
+        # JSON file should exist; temp file should not
+        assert (tmp_path / "results.json").exists()
+        assert not (tmp_path / "results.json.tmp").exists()

--- a/tests/test_spatial_pipeline.py
+++ b/tests/test_spatial_pipeline.py
@@ -1,0 +1,147 @@
+"""Tests for spatial pipeline components."""
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from dino.config import SpatialConfig
+
+
+class TestSpatialConfig:
+    def test_defaults(self):
+        config = SpatialConfig()
+        assert config.camera_mode == "fixed"
+        assert config.match_distance == 50.0
+        assert config.max_age_seconds == 30.0
+        assert config.zones_path is None
+        assert config.rules is None
+
+    def test_invalid_camera_mode(self):
+        with pytest.raises(ValueError, match="Unsupported camera_mode"):
+            SpatialConfig(camera_mode="moving")
+
+    def test_invalid_match_distance(self):
+        with pytest.raises(ValueError, match="match_distance must be > 0"):
+            SpatialConfig(match_distance=0)
+
+    def test_invalid_max_age(self):
+        with pytest.raises(ValueError, match="max_age_seconds must be > 0"):
+            SpatialConfig(max_age_seconds=-1)
+
+
+class TestLoadZonesFile:
+    def test_load_valid_file(self, tmp_path):
+        from dino.zones.loader import load_zones_file
+        zones_data = {
+            "zones": [
+                {"zone_id": "z1", "name": "Zone 1", "polygon": [[0,0],[100,0],[100,100],[0,100]]},
+            ],
+            "rules": [
+                {"event_type": "occupied", "requires_any": ["person"]},
+            ],
+        }
+        path = tmp_path / "zones.json"
+        path.write_text(json.dumps(zones_data))
+
+        zones, rules = load_zones_file(path)
+        assert len(zones) == 1
+        assert zones[0].zone_id == "z1"
+        assert zones[0].name == "Zone 1"
+        assert zones[0].polygon.shape == (4, 2)
+        assert len(rules) == 1
+        assert rules[0].event_type == "occupied"
+
+    def test_file_not_found(self):
+        from dino.zones.loader import load_zones_file
+        with pytest.raises(FileNotFoundError):
+            load_zones_file("/nonexistent/zones.json")
+
+    def test_missing_zones_key(self, tmp_path):
+        from dino.zones.loader import load_zones_file
+        path = tmp_path / "bad.json"
+        path.write_text(json.dumps({"rules": []}))
+        with pytest.raises(ValueError, match="must contain a 'zones' key"):
+            load_zones_file(path)
+
+    def test_no_rules_section(self, tmp_path):
+        from dino.zones.loader import load_zones_file
+        zones_data = {
+            "zones": [
+                {"zone_id": "z1", "name": "Zone 1", "polygon": [[0,0],[100,0],[100,100],[0,100]]},
+            ],
+        }
+        path = tmp_path / "zones.json"
+        path.write_text(json.dumps(zones_data))
+
+        zones, rules = load_zones_file(path)
+        assert len(zones) == 1
+        assert len(rules) == 0
+
+
+class TestZoneAnnotator:
+    def _make_zone(self, zone_id="z1", name="Test Zone"):
+        from dino.zones.models import ZoneDefinition
+
+        return ZoneDefinition(
+            zone_id=zone_id,
+            name=name,
+            polygon=np.array(
+                [[10, 10], [100, 10], [100, 100], [10, 100]], dtype=np.float64
+            ),
+        )
+
+    def _make_frame(self, h=240, w=320):
+        return np.zeros((h, w, 3), dtype=np.uint8)
+
+    def test_annotate_returns_copy(self):
+        from dino.annotation.zone_annotator import ZoneAnnotator
+
+        annotator = ZoneAnnotator()
+        frame = self._make_frame()
+        zone = self._make_zone()
+        result = annotator.annotate(frame, [zone])
+        # Input should not be modified
+        assert np.array_equal(frame, np.zeros_like(frame))
+        # Result should be a different array
+        assert result is not frame
+
+    def test_annotate_draws_on_frame(self):
+        from dino.annotation.zone_annotator import ZoneAnnotator
+
+        annotator = ZoneAnnotator()
+        frame = self._make_frame()
+        zone = self._make_zone()
+        result = annotator.annotate(frame, [zone])
+        # Output should differ from blank input (zone was drawn)
+        assert not np.array_equal(result, frame)
+
+    def test_active_zone_different_color(self):
+        from dino.annotation.zone_annotator import ZoneAnnotator
+        from dino.spatial.models import WorldObject
+        from dino.zones.models import ZoneState
+
+        annotator = ZoneAnnotator()
+        zone = self._make_zone()
+
+        # Inactive frame
+        frame1 = self._make_frame()
+        result_inactive = annotator.annotate(frame1, [zone])
+
+        # Active frame (zone has present objects)
+        frame2 = self._make_frame()
+        obj = WorldObject(
+            tracker_id=1,
+            bbox_xyxy=np.array([10, 10, 50, 50]),
+            world_position=np.array([30, 30, 0]),
+            persistent_id=1,
+            class_name="person",
+        )
+        zone_states = {
+            "z1": ZoneState(zone_id="z1", present_objects={1: obj}),
+        }
+        result_active = annotator.annotate(frame2, [zone], zone_states=zone_states)
+
+        # Active and inactive should produce different results
+        assert not np.array_equal(result_inactive, result_active)

--- a/tests/test_spatial_pipeline.py
+++ b/tests/test_spatial_pipeline.py
@@ -481,14 +481,18 @@ class TestSpatialPipeline:
         assert "inline_rule" in event_types
         assert "file_rule" not in event_types
 
-    def test_progress_callback_exception_does_not_kill_pipeline(self, tmp_path):
+    def test_progress_callback_exception_disables_callback(self, tmp_path):
         from dino.spatial.spatial_pipeline import SpatialPipeline
 
         input_path = str(tmp_path / "input.mp4")
         output_path = str(tmp_path / "output.mp4")
         _make_test_video(input_path, num_frames=3)
 
+        call_count = 0
+
         def bad_callback(p, t):
+            nonlocal call_count
+            call_count += 1
             raise RuntimeError("callback boom")
 
         detector = self._make_mock_detector()
@@ -498,6 +502,8 @@ class TestSpatialPipeline:
         # Should complete without raising
         results = pipeline.run(input_path, output_path, progress_callback=bad_callback)
         assert len(results.frame_results) == 3
+        # Callback should be called once, then disabled after failure
+        assert call_count == 1
 
     def test_json_export_atomic_no_partial_file(self, tmp_path):
         from dino.spatial.spatial_pipeline import SpatialPipeline
@@ -516,3 +522,47 @@ class TestSpatialPipeline:
         # JSON file should exist; temp file should not
         assert (tmp_path / "results.json").exists()
         assert not (tmp_path / "results.json.tmp").exists()
+
+    def test_detector_exception_wraps_with_frame_context(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        _make_test_video(input_path, num_frames=3)
+
+        detector = self._make_mock_detector()
+        detector.detect.side_effect = ValueError("model OOM")
+        config = PipelineConfig(prompts=["person"])
+        spatial_config = SpatialConfig()
+        pipeline = SpatialPipeline(detector, config, spatial_config)
+
+        with pytest.raises(RuntimeError, match="Error processing frame 0") as exc_info:
+            pipeline.run(input_path, output_path)
+        assert isinstance(exc_info.value.__cause__, ValueError)
+
+    def test_invalid_inline_rule_no_conditions_raises(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        detector = self._make_mock_detector()
+        config = PipelineConfig(prompts=["person"])
+        spatial_config = SpatialConfig(
+            rules=[{"event_type": "bad_rule"}],
+        )
+        with pytest.raises(ValueError, match="Invalid inline rule at index 0"):
+            SpatialPipeline(detector, config, spatial_config)
+
+
+class TestLoadZonesFileEdgeCases:
+    def test_invalid_polygon_too_few_vertices(self, tmp_path):
+        from dino.zones.loader import load_zones_file
+
+        zones_data = {
+            "zones": [
+                {"zone_id": "z1", "name": "Bad Zone", "polygon": [[0, 0], [100, 0]]},
+            ],
+        }
+        path = tmp_path / "zones.json"
+        path.write_text(json.dumps(zones_data))
+
+        with pytest.raises(ValueError, match="Invalid zone entry 0"):
+            load_zones_file(path)

--- a/tests/test_spatial_pipeline.py
+++ b/tests/test_spatial_pipeline.py
@@ -17,6 +17,11 @@ def _make_test_video(path: str, num_frames: int = 10, fps: int = 30):
     h, w = 240, 320
     fourcc = cv2.VideoWriter_fourcc(*"mp4v")
     writer = cv2.VideoWriter(path, fourcc, fps, (w, h))
+    if not writer.isOpened():
+        raise RuntimeError(
+            f"Failed to open VideoWriter at {path} with mp4v codec. "
+            f"Check that OpenCV was built with mp4v support."
+        )
     for i in range(num_frames):
         frame = np.zeros((h, w, 3), dtype=np.uint8)
         frame[:] = (i * 25, i * 10, 0)
@@ -45,13 +50,18 @@ class TestSpatialConfig:
         with pytest.raises(ValueError, match="max_age_seconds must be > 0"):
             SpatialConfig(max_age_seconds=-1)
 
+    def test_invalid_rules_missing_event_type(self):
+        with pytest.raises(ValueError, match="missing required key 'event_type'"):
+            SpatialConfig(rules=[{"requires_any": ["person"]}])
+
 
 class TestLoadZonesFile:
     def test_load_valid_file(self, tmp_path):
         from dino.zones.loader import load_zones_file
+
         zones_data = {
             "zones": [
-                {"zone_id": "z1", "name": "Zone 1", "polygon": [[0,0],[100,0],[100,100],[0,100]]},
+                {"zone_id": "z1", "name": "Zone 1", "polygon": [[0, 0], [100, 0], [100, 100], [0, 100]]},
             ],
             "rules": [
                 {"event_type": "occupied", "requires_any": ["person"]},
@@ -70,11 +80,13 @@ class TestLoadZonesFile:
 
     def test_file_not_found(self):
         from dino.zones.loader import load_zones_file
+
         with pytest.raises(FileNotFoundError):
             load_zones_file("/nonexistent/zones.json")
 
     def test_missing_zones_key(self, tmp_path):
         from dino.zones.loader import load_zones_file
+
         path = tmp_path / "bad.json"
         path.write_text(json.dumps({"rules": []}))
         with pytest.raises(ValueError, match="must contain a 'zones' key"):
@@ -82,9 +94,10 @@ class TestLoadZonesFile:
 
     def test_no_rules_section(self, tmp_path):
         from dino.zones.loader import load_zones_file
+
         zones_data = {
             "zones": [
-                {"zone_id": "z1", "name": "Zone 1", "polygon": [[0,0],[100,0],[100,100],[0,100]]},
+                {"zone_id": "z1", "name": "Zone 1", "polygon": [[0, 0], [100, 0], [100, 100], [0, 100]]},
             ],
         }
         path = tmp_path / "zones.json"
@@ -93,6 +106,27 @@ class TestLoadZonesFile:
         zones, rules = load_zones_file(path)
         assert len(zones) == 1
         assert len(rules) == 0
+
+    def test_missing_zone_keys(self, tmp_path):
+        from dino.zones.loader import load_zones_file
+
+        zones_data = {
+            "zones": [
+                {"zone_id": "z1", "polygon": [[0, 0], [100, 0], [100, 100], [0, 100]]},
+            ],
+        }
+        path = tmp_path / "zones.json"
+        path.write_text(json.dumps(zones_data))
+        with pytest.raises(ValueError, match="missing required keys"):
+            load_zones_file(path)
+
+    def test_invalid_json(self, tmp_path):
+        from dino.zones.loader import load_zones_file
+
+        path = tmp_path / "bad.json"
+        path.write_text("not valid json {")
+        with pytest.raises(ValueError, match="invalid JSON"):
+            load_zones_file(path)
 
 
 class TestZoneAnnotator:
@@ -160,6 +194,16 @@ class TestZoneAnnotator:
 
         # Active and inactive should produce different results
         assert not np.array_equal(result_inactive, result_active)
+
+    def test_annotate_empty_zones(self):
+        from dino.annotation.zone_annotator import ZoneAnnotator
+
+        annotator = ZoneAnnotator()
+        frame = self._make_frame()
+        result = annotator.annotate(frame, [])
+        # Should return a copy even with no zones
+        assert result is not frame
+        assert np.array_equal(result, frame)
 
 
 class TestSpatialPipeline:
@@ -235,8 +279,11 @@ class TestSpatialPipeline:
         results = pipeline.run(input_path, output_path)
 
         assert len(results.frame_results) == 5
-        assert len(results.observations) > 0
-        assert len(results.events) > 0
+        # 1 ENTER on frame 0, 4 PRESENT on frames 1-4
+        assert len(results.observations) == 5
+        # 1 occupied event (hysteresis=1, latches after firing)
+        assert len(results.events) == 1
+        assert results.events[0]["event_type"] == "occupied"
 
     def test_run_input_not_found(self, tmp_path):
         from dino.spatial.spatial_pipeline import SpatialPipeline
@@ -269,6 +316,63 @@ class TestSpatialPipeline:
         assert "observations" in data
         assert "events" in data
 
+    def test_json_export_with_detections(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        json_path = str(tmp_path / "results.json")
+        _make_test_video(input_path, num_frames=3)
+
+        zones_data = {
+            "zones": [
+                {
+                    "zone_id": "z1",
+                    "name": "Zone 1",
+                    "polygon": [[0, 0], [200, 0], [200, 200], [0, 200]],
+                },
+            ],
+            "rules": [
+                {"event_type": "occupied", "requires_any": ["person"]},
+            ],
+        }
+        zones_path = str(tmp_path / "zones.json")
+        with open(zones_path, "w") as f:
+            json.dump(zones_data, f)
+
+        dets = self._make_detections(n=1)
+        detector = self._make_mock_detector(dets)
+        config = PipelineConfig(prompts=["person"])
+        spatial_config = SpatialConfig(zones_path=zones_path)
+        pipeline = SpatialPipeline(detector, config, spatial_config)
+        pipeline.run(input_path, output_path, json_output=json_path)
+
+        with open(json_path) as f:
+            data = json.load(f)
+
+        # Verify frame result dict structure
+        frame = data["frames"][0]
+        assert "frame_idx" in frame
+        assert "timestamp" in frame
+        assert "objects" in frame
+        assert len(frame["objects"]) > 0
+        obj = frame["objects"][0]
+        for key in ("persistent_id", "tracker_id", "class_name", "confidence",
+                     "bbox", "world_position", "zone_id"):
+            assert key in obj, f"Missing key {key} in object dict"
+
+        # Verify observation dict structure
+        assert len(data["observations"]) > 0
+        obs = data["observations"][0]
+        for key in ("zone_id", "persistent_id", "observation_type", "frame_idx", "timestamp"):
+            assert key in obs, f"Missing key {key} in observation dict"
+
+        # Verify event dict structure
+        assert len(data["events"]) > 0
+        event = data["events"][0]
+        for key in ("zone_id", "event_type", "frame_idx", "timestamp", "details"):
+            assert key in event, f"Missing key {key} in event dict"
+
     def test_progress_callback(self, tmp_path):
         from dino.spatial.spatial_pipeline import SpatialPipeline
 
@@ -284,11 +388,12 @@ class TestSpatialPipeline:
         pipeline.run(
             input_path,
             output_path,
-            progress_callback=lambda i, t: calls.append((i, t)),
+            progress_callback=lambda p, t: calls.append((p, t)),
         )
 
         assert len(calls) == 6
-        assert all(t == 6 for _, t in calls)
+        # Callback receives (processed_count, total_frames)
+        assert calls == [(i + 1, 6) for i in range(6)]
 
     def test_stride_skips_frames(self, tmp_path):
         from dino.spatial.spatial_pipeline import SpatialPipeline
@@ -336,5 +441,42 @@ class TestSpatialPipeline:
         pipeline = SpatialPipeline(detector, config, spatial_config)
         results = pipeline.run(input_path, output_path)
 
-        assert len(results.events) > 0
+        assert len(results.events) == 1
         assert results.events[0]["event_type"] == "occupied"
+
+    def test_inline_rules_override_file_rules(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        _make_test_video(input_path, num_frames=3)
+
+        zones_data = {
+            "zones": [
+                {
+                    "zone_id": "z1",
+                    "name": "Zone 1",
+                    "polygon": [[0, 0], [200, 0], [200, 200], [0, 200]],
+                },
+            ],
+            "rules": [
+                {"event_type": "file_rule", "requires_any": ["person"]},
+            ],
+        }
+        zones_path = str(tmp_path / "zones.json")
+        with open(zones_path, "w") as f:
+            json.dump(zones_data, f)
+
+        dets = self._make_detections(n=1)
+        detector = self._make_mock_detector(dets)
+        config = PipelineConfig(prompts=["person"])
+        spatial_config = SpatialConfig(
+            zones_path=zones_path,
+            rules=[{"event_type": "inline_rule", "requires_any": ["person"]}],
+        )
+        pipeline = SpatialPipeline(detector, config, spatial_config)
+        results = pipeline.run(input_path, output_path)
+
+        event_types = [e["event_type"] for e in results.events]
+        assert "inline_rule" in event_types
+        assert "file_rule" not in event_types

--- a/tests/test_spatial_pipeline.py
+++ b/tests/test_spatial_pipeline.py
@@ -2,11 +2,26 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import MagicMock
 
+import cv2
 import numpy as np
 import pytest
+import supervision as sv
 
-from dino.config import SpatialConfig
+from dino.config import PipelineConfig, SpatialConfig
+
+
+def _make_test_video(path: str, num_frames: int = 10, fps: int = 30):
+    """Create a small test video (240x320, mp4v codec)."""
+    h, w = 240, 320
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(path, fourcc, fps, (w, h))
+    for i in range(num_frames):
+        frame = np.zeros((h, w, 3), dtype=np.uint8)
+        frame[:] = (i * 25, i * 10, 0)
+        writer.write(frame)
+    writer.release()
 
 
 class TestSpatialConfig:
@@ -145,3 +160,181 @@ class TestZoneAnnotator:
 
         # Active and inactive should produce different results
         assert not np.array_equal(result_inactive, result_active)
+
+
+class TestSpatialPipeline:
+    def _make_mock_detector(self, detections=None):
+        detector = MagicMock()
+        if detections is None:
+            detector.detect.return_value = sv.Detections.empty()
+        else:
+            detector.detect.return_value = detections
+        return detector
+
+    def _make_detections(self, n=1):
+        """Create mock detections with n bounding boxes inside a 320x240 frame."""
+        xyxy = np.array(
+            [[50 + i * 10, 50, 90 + i * 10, 90] for i in range(n)],
+            dtype=np.float32,
+        )
+        confidence = np.array([0.9] * n, dtype=np.float32)
+        class_id = np.array([0] * n, dtype=int)
+        return sv.Detections(
+            xyxy=xyxy,
+            confidence=confidence,
+            class_id=class_id,
+            data={"class_name": np.array(["person"] * n)},
+        )
+
+    def test_run_produces_output_no_zones(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        _make_test_video(input_path, num_frames=5)
+
+        detector = self._make_mock_detector()
+        config = PipelineConfig(prompts=["person"], stride=1)
+        spatial_config = SpatialConfig()
+        pipeline = SpatialPipeline(detector, config, spatial_config)
+        results = pipeline.run(input_path, output_path)
+
+        assert (tmp_path / "output.mp4").exists()
+        assert isinstance(results.frame_results, list)
+        assert isinstance(results.observations, list)
+        assert isinstance(results.events, list)
+
+    def test_run_with_zones_and_detections(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        _make_test_video(input_path, num_frames=5)
+
+        zones_data = {
+            "zones": [
+                {
+                    "zone_id": "z1",
+                    "name": "Zone 1",
+                    "polygon": [[0, 0], [200, 0], [200, 200], [0, 200]],
+                },
+            ],
+            "rules": [
+                {"event_type": "occupied", "requires_any": ["person"], "hysteresis": 1},
+            ],
+        }
+        zones_path = str(tmp_path / "zones.json")
+        with open(zones_path, "w") as f:
+            json.dump(zones_data, f)
+
+        dets = self._make_detections(n=1)
+        detector = self._make_mock_detector(dets)
+        config = PipelineConfig(prompts=["person"], stride=1)
+        spatial_config = SpatialConfig(zones_path=zones_path)
+        pipeline = SpatialPipeline(detector, config, spatial_config)
+        results = pipeline.run(input_path, output_path)
+
+        assert len(results.frame_results) == 5
+        assert len(results.observations) > 0
+        assert len(results.events) > 0
+
+    def test_run_input_not_found(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        detector = self._make_mock_detector()
+        config = PipelineConfig(prompts=["person"])
+        spatial_config = SpatialConfig()
+        pipeline = SpatialPipeline(detector, config, spatial_config)
+        with pytest.raises(FileNotFoundError):
+            pipeline.run("/nonexistent/video.mp4", str(tmp_path / "out.mp4"))
+
+    def test_json_export_structure(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        json_path = str(tmp_path / "results.json")
+        _make_test_video(input_path, num_frames=3)
+
+        detector = self._make_mock_detector()
+        config = PipelineConfig(prompts=["person"])
+        spatial_config = SpatialConfig()
+        pipeline = SpatialPipeline(detector, config, spatial_config)
+        pipeline.run(input_path, output_path, json_output=json_path)
+
+        assert (tmp_path / "results.json").exists()
+        with open(json_path) as f:
+            data = json.load(f)
+        assert "frames" in data
+        assert "observations" in data
+        assert "events" in data
+
+    def test_progress_callback(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        _make_test_video(input_path, num_frames=6)
+
+        calls = []
+        detector = self._make_mock_detector()
+        config = PipelineConfig(prompts=["person"])
+        spatial_config = SpatialConfig()
+        pipeline = SpatialPipeline(detector, config, spatial_config)
+        pipeline.run(
+            input_path,
+            output_path,
+            progress_callback=lambda i, t: calls.append((i, t)),
+        )
+
+        assert len(calls) == 6
+        assert all(t == 6 for _, t in calls)
+
+    def test_stride_skips_frames(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        _make_test_video(input_path, num_frames=9)
+
+        detector = self._make_mock_detector()
+        config = PipelineConfig(prompts=["person"], stride=3)
+        spatial_config = SpatialConfig()
+        pipeline = SpatialPipeline(detector, config, spatial_config)
+        results = pipeline.run(input_path, output_path)
+
+        # Frames 0, 3, 6 should be processed (3 frames)
+        assert len(results.frame_results) == 3
+
+    def test_inline_rules(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        _make_test_video(input_path, num_frames=3)
+
+        zones_data = {
+            "zones": [
+                {
+                    "zone_id": "z1",
+                    "name": "Zone 1",
+                    "polygon": [[0, 0], [200, 0], [200, 200], [0, 200]],
+                },
+            ],
+        }
+        zones_path = str(tmp_path / "zones.json")
+        with open(zones_path, "w") as f:
+            json.dump(zones_data, f)
+
+        dets = self._make_detections(n=1)
+        detector = self._make_mock_detector(dets)
+        config = PipelineConfig(prompts=["person"])
+        spatial_config = SpatialConfig(
+            zones_path=zones_path,
+            rules=[{"event_type": "occupied", "requires_any": ["person"]}],
+        )
+        pipeline = SpatialPipeline(detector, config, spatial_config)
+        results = pipeline.run(input_path, output_path)
+
+        assert len(results.events) > 0
+        assert results.events[0]["event_type"] == "occupied"

--- a/tests/test_spatial_pipeline.py
+++ b/tests/test_spatial_pipeline.py
@@ -128,6 +128,20 @@ class TestLoadZonesFile:
         with pytest.raises(ValueError, match="invalid JSON"):
             load_zones_file(path)
 
+    def test_invalid_polygon_too_few_vertices(self, tmp_path):
+        from dino.zones.loader import load_zones_file
+
+        zones_data = {
+            "zones": [
+                {"zone_id": "z1", "name": "Bad Zone", "polygon": [[0, 0], [100, 0]]},
+            ],
+        }
+        path = tmp_path / "zones.json"
+        path.write_text(json.dumps(zones_data))
+
+        with pytest.raises(ValueError, match="Invalid zone entry 0"):
+            load_zones_file(path)
+
 
 class TestZoneAnnotator:
     def _make_zone(self, zone_id="z1", name="Test Zone"):
@@ -550,19 +564,3 @@ class TestSpatialPipeline:
         )
         with pytest.raises(ValueError, match="Invalid inline rule at index 0"):
             SpatialPipeline(detector, config, spatial_config)
-
-
-class TestLoadZonesFileEdgeCases:
-    def test_invalid_polygon_too_few_vertices(self, tmp_path):
-        from dino.zones.loader import load_zones_file
-
-        zones_data = {
-            "zones": [
-                {"zone_id": "z1", "name": "Bad Zone", "polygon": [[0, 0], [100, 0]]},
-            ],
-        }
-        path = tmp_path / "zones.json"
-        path.write_text(json.dumps(zones_data))
-
-        with pytest.raises(ValueError, match="Invalid zone entry 0"):
-            load_zones_file(path)


### PR DESCRIPTION
## Summary

- Add `SpatialPipeline` that orchestrates the full detect → track → localize → register → zone update → rule eval → annotate → export pipeline in a single `run()` call
- Add `SpatialConfig` dataclass for spatial processing configuration (camera mode, match distance, zones path, inline rules)
- Add `load_zones_file()` for loading zone definitions and event rules from JSON
- Add `ZoneAnnotator` for drawing semi-transparent zone polygon overlays on video frames
- Add `demo_spatial.py` CLI entry point for running the spatial pipeline on videos
- 29 tests covering config validation, zone loading, annotation, and full pipeline integration

## Test plan

- [x] `uv run pytest tests/ -v` — all 193 tests pass
- [x] 5 rounds of review triangle (code-reviewer, silent-failure-hunter, type-design-analyzer, pr-test-analyzer) — all clean
- [ ] Manual: `python scripts/demo_spatial.py --input <video> --output out/ --zones zones.json --prompts person`

Fixes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)