### PR TITLE
feat: 3D spatial map viewer core

### DIFF
--- a/src/dino/spatial/spatial_pipeline.py
+++ b/src/dino/spatial/spatial_pipeline.py
@@ -199,6 +199,18 @@ class SpatialPipeline:
                 with open(tmp_path, "w") as f:
                     json.dump(
                         {
+                            "metadata": {
+                                "fps": float(adjusted_fps),
+                                "width": video_info.width,
+                                "height": video_info.height,
+                                "total_frames": total_frames,
+                                "duration_sec": round(total_frames / adjusted_fps, 3),
+                                "stride": self.config.stride,
+                            },
+                            "zones": [
+                                {"zone_id": z.zone_id, "name": z.name, "polygon": z.polygon.tolist()}
+                                for z in self._zones
+                            ],
                             "frames": results.frame_results,
                             "observations": results.observations,
                             "events": results.events,

--- a/src/dino/spatial/spatial_pipeline.py
+++ b/src/dino/spatial/spatial_pipeline.py
@@ -219,7 +219,7 @@ class SpatialPipeline:
                         indent=2,
                     )
                 tmp_path.replace(json_path)
-            except (TypeError, OSError) as e:
+            except Exception as e:
                 if tmp_path.exists():
                     tmp_path.unlink()
                 raise RuntimeError(

--- a/src/dino/spatial/spatial_pipeline.py
+++ b/src/dino/spatial/spatial_pipeline.py
@@ -168,7 +168,7 @@ class SpatialPipeline:
                     frame_result = self._process_frame(
                         frame, frame_idx, timestamp, sink
                     )
-                except Exception as e:
+                except (TypeError, ValueError, OSError) as e:
                     raise RuntimeError(
                         f"Error processing frame {frame_idx}: {e}"
                     ) from e

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,51 @@
+"""Shared test helpers for the DINO test suite."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import cv2
+import numpy as np
+import supervision as sv
+
+
+def make_test_video(path: str, num_frames: int = 10, fps: int = 30):
+    """Create a small test video (240x320, mp4v codec)."""
+    h, w = 240, 320
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(path, fourcc, fps, (w, h))
+    if not writer.isOpened():
+        raise RuntimeError(
+            f"Failed to open VideoWriter at {path} with mp4v codec. "
+            f"Check that OpenCV was built with mp4v support."
+        )
+    for i in range(num_frames):
+        frame = np.zeros((h, w, 3), dtype=np.uint8)
+        frame[:] = (i * 25, i * 10, 0)
+        writer.write(frame)
+    writer.release()
+
+
+def make_mock_detector(detections=None):
+    """Create a mock detector that returns the given detections."""
+    detector = MagicMock()
+    if detections is None:
+        detector.detect.return_value = sv.Detections.empty()
+    else:
+        detector.detect.return_value = detections
+    return detector
+
+
+def make_detections(n=1):
+    """Create mock detections with n bounding boxes inside a 320x240 frame."""
+    xyxy = np.array(
+        [[50 + i * 10, 50, 90 + i * 10, 90] for i in range(n)],
+        dtype=np.float32,
+    )
+    confidence = np.array([0.9] * n, dtype=np.float32)
+    class_id = np.array([0] * n, dtype=int)
+    return sv.Detections(
+        xyxy=xyxy,
+        confidence=confidence,
+        class_id=class_id,
+        data={"class_name": np.array(["person"] * n)},
+    )

--- a/tests/test_spatial_pipeline.py
+++ b/tests/test_spatial_pipeline.py
@@ -564,3 +564,105 @@ class TestSpatialPipeline:
         )
         with pytest.raises(ValueError, match="Invalid inline rule at index 0"):
             SpatialPipeline(detector, config, spatial_config)
+
+    def test_json_export_has_metadata(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        json_path = str(tmp_path / "results.json")
+        num_frames = 5
+        _make_test_video(input_path, num_frames=num_frames, fps=30)
+
+        detector = self._make_mock_detector()
+        config = PipelineConfig(prompts=["person"])
+        spatial_config = SpatialConfig()
+        pipeline = SpatialPipeline(detector, config, spatial_config)
+        pipeline.run(input_path, output_path, json_output=json_path)
+
+        with open(json_path) as f:
+            data = json.load(f)
+
+        assert "metadata" in data
+        m = data["metadata"]
+        assert isinstance(m["fps"], float)
+        assert isinstance(m["width"], int)
+        assert isinstance(m["height"], int)
+        assert isinstance(m["total_frames"], int)
+        assert isinstance(m["duration_sec"], float)
+        assert isinstance(m["stride"], int)
+        assert m["width"] == 320
+        assert m["height"] == 240
+        assert m["fps"] == 30.0
+        assert m["total_frames"] == num_frames
+        assert m["stride"] == 1
+
+    def test_json_export_has_zones(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        json_path = str(tmp_path / "results.json")
+        _make_test_video(input_path, num_frames=5)
+
+        zones_data = {
+            "zones": [
+                {
+                    "zone_id": "z1",
+                    "name": "Zone 1",
+                    "polygon": [[0, 0], [200, 0], [200, 200], [0, 200]],
+                },
+            ],
+            "rules": [
+                {"event_type": "occupied", "requires_any": ["person"], "hysteresis": 1},
+            ],
+        }
+        zones_path = str(tmp_path / "zones.json")
+        with open(zones_path, "w") as f:
+            json.dump(zones_data, f)
+
+        dets = self._make_detections(n=1)
+        detector = self._make_mock_detector(dets)
+        config = PipelineConfig(prompts=["person"])
+        spatial_config = SpatialConfig(zones_path=zones_path)
+        pipeline = SpatialPipeline(detector, config, spatial_config)
+        pipeline.run(input_path, output_path, json_output=json_path)
+
+        with open(json_path) as f:
+            data = json.load(f)
+
+        assert "zones" in data
+        assert isinstance(data["zones"], list)
+        assert len(data["zones"]) == 1
+        z = data["zones"][0]
+        assert z["zone_id"] == "z1"
+        assert z["name"] == "Zone 1"
+        assert isinstance(z["polygon"], list)
+        assert all(len(pt) == 2 for pt in z["polygon"])
+
+    def test_json_export_metadata_without_zones(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        json_path = str(tmp_path / "results.json")
+        num_frames = 5
+        _make_test_video(input_path, num_frames=num_frames, fps=30)
+
+        detector = self._make_mock_detector()
+        config = PipelineConfig(prompts=["person"])
+        spatial_config = SpatialConfig()
+        pipeline = SpatialPipeline(detector, config, spatial_config)
+        pipeline.run(input_path, output_path, json_output=json_path)
+
+        with open(json_path) as f:
+            data = json.load(f)
+
+        assert "metadata" in data
+        assert data["metadata"]["width"] == 320
+        assert data["metadata"]["height"] == 240
+        assert data["metadata"]["fps"] == 30.0
+        assert data["metadata"]["total_frames"] == num_frames
+        assert data["metadata"]["stride"] == 1
+        assert "zones" in data
+        assert data["zones"] == []

--- a/tests/test_spatial_pipeline.py
+++ b/tests/test_spatial_pipeline.py
@@ -2,31 +2,12 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock
 
-import cv2
 import numpy as np
 import pytest
-import supervision as sv
 
+from tests.helpers import make_test_video, make_mock_detector, make_detections
 from dino.config import PipelineConfig, SpatialConfig
-
-
-def _make_test_video(path: str, num_frames: int = 10, fps: int = 30):
-    """Create a small test video (240x320, mp4v codec)."""
-    h, w = 240, 320
-    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
-    writer = cv2.VideoWriter(path, fourcc, fps, (w, h))
-    if not writer.isOpened():
-        raise RuntimeError(
-            f"Failed to open VideoWriter at {path} with mp4v codec. "
-            f"Check that OpenCV was built with mp4v support."
-        )
-    for i in range(num_frames):
-        frame = np.zeros((h, w, 3), dtype=np.uint8)
-        frame[:] = (i * 25, i * 10, 0)
-        writer.write(frame)
-    writer.release()
 
 
 class TestSpatialConfig:
@@ -221,37 +202,14 @@ class TestZoneAnnotator:
 
 
 class TestSpatialPipeline:
-    def _make_mock_detector(self, detections=None):
-        detector = MagicMock()
-        if detections is None:
-            detector.detect.return_value = sv.Detections.empty()
-        else:
-            detector.detect.return_value = detections
-        return detector
-
-    def _make_detections(self, n=1):
-        """Create mock detections with n bounding boxes inside a 320x240 frame."""
-        xyxy = np.array(
-            [[50 + i * 10, 50, 90 + i * 10, 90] for i in range(n)],
-            dtype=np.float32,
-        )
-        confidence = np.array([0.9] * n, dtype=np.float32)
-        class_id = np.array([0] * n, dtype=int)
-        return sv.Detections(
-            xyxy=xyxy,
-            confidence=confidence,
-            class_id=class_id,
-            data={"class_name": np.array(["person"] * n)},
-        )
-
     def test_run_produces_output_no_zones(self, tmp_path):
         from dino.spatial.spatial_pipeline import SpatialPipeline
 
         input_path = str(tmp_path / "input.mp4")
         output_path = str(tmp_path / "output.mp4")
-        _make_test_video(input_path, num_frames=5)
+        make_test_video(input_path, num_frames=5)
 
-        detector = self._make_mock_detector()
+        detector = make_mock_detector()
         config = PipelineConfig(prompts=["person"], stride=1)
         spatial_config = SpatialConfig()
         pipeline = SpatialPipeline(detector, config, spatial_config)
@@ -267,7 +225,7 @@ class TestSpatialPipeline:
 
         input_path = str(tmp_path / "input.mp4")
         output_path = str(tmp_path / "output.mp4")
-        _make_test_video(input_path, num_frames=5)
+        make_test_video(input_path, num_frames=5)
 
         zones_data = {
             "zones": [
@@ -285,8 +243,8 @@ class TestSpatialPipeline:
         with open(zones_path, "w") as f:
             json.dump(zones_data, f)
 
-        dets = self._make_detections(n=1)
-        detector = self._make_mock_detector(dets)
+        dets = make_detections(n=1)
+        detector = make_mock_detector(dets)
         config = PipelineConfig(prompts=["person"], stride=1)
         spatial_config = SpatialConfig(zones_path=zones_path)
         pipeline = SpatialPipeline(detector, config, spatial_config)
@@ -302,7 +260,7 @@ class TestSpatialPipeline:
     def test_run_input_not_found(self, tmp_path):
         from dino.spatial.spatial_pipeline import SpatialPipeline
 
-        detector = self._make_mock_detector()
+        detector = make_mock_detector()
         config = PipelineConfig(prompts=["person"])
         spatial_config = SpatialConfig()
         pipeline = SpatialPipeline(detector, config, spatial_config)
@@ -315,9 +273,9 @@ class TestSpatialPipeline:
         input_path = str(tmp_path / "input.mp4")
         output_path = str(tmp_path / "output.mp4")
         json_path = str(tmp_path / "results.json")
-        _make_test_video(input_path, num_frames=3)
+        make_test_video(input_path, num_frames=3)
 
-        detector = self._make_mock_detector()
+        detector = make_mock_detector()
         config = PipelineConfig(prompts=["person"])
         spatial_config = SpatialConfig()
         pipeline = SpatialPipeline(detector, config, spatial_config)
@@ -336,7 +294,7 @@ class TestSpatialPipeline:
         input_path = str(tmp_path / "input.mp4")
         output_path = str(tmp_path / "output.mp4")
         json_path = str(tmp_path / "results.json")
-        _make_test_video(input_path, num_frames=3)
+        make_test_video(input_path, num_frames=3)
 
         zones_data = {
             "zones": [
@@ -354,8 +312,8 @@ class TestSpatialPipeline:
         with open(zones_path, "w") as f:
             json.dump(zones_data, f)
 
-        dets = self._make_detections(n=1)
-        detector = self._make_mock_detector(dets)
+        dets = make_detections(n=1)
+        detector = make_mock_detector(dets)
         config = PipelineConfig(prompts=["person"])
         spatial_config = SpatialConfig(zones_path=zones_path)
         pipeline = SpatialPipeline(detector, config, spatial_config)
@@ -392,10 +350,10 @@ class TestSpatialPipeline:
 
         input_path = str(tmp_path / "input.mp4")
         output_path = str(tmp_path / "output.mp4")
-        _make_test_video(input_path, num_frames=6)
+        make_test_video(input_path, num_frames=6)
 
         calls = []
-        detector = self._make_mock_detector()
+        detector = make_mock_detector()
         config = PipelineConfig(prompts=["person"])
         spatial_config = SpatialConfig()
         pipeline = SpatialPipeline(detector, config, spatial_config)
@@ -414,9 +372,9 @@ class TestSpatialPipeline:
 
         input_path = str(tmp_path / "input.mp4")
         output_path = str(tmp_path / "output.mp4")
-        _make_test_video(input_path, num_frames=9)
+        make_test_video(input_path, num_frames=9)
 
-        detector = self._make_mock_detector()
+        detector = make_mock_detector()
         config = PipelineConfig(prompts=["person"], stride=3)
         spatial_config = SpatialConfig()
         pipeline = SpatialPipeline(detector, config, spatial_config)
@@ -430,7 +388,7 @@ class TestSpatialPipeline:
 
         input_path = str(tmp_path / "input.mp4")
         output_path = str(tmp_path / "output.mp4")
-        _make_test_video(input_path, num_frames=3)
+        make_test_video(input_path, num_frames=3)
 
         zones_data = {
             "zones": [
@@ -445,8 +403,8 @@ class TestSpatialPipeline:
         with open(zones_path, "w") as f:
             json.dump(zones_data, f)
 
-        dets = self._make_detections(n=1)
-        detector = self._make_mock_detector(dets)
+        dets = make_detections(n=1)
+        detector = make_mock_detector(dets)
         config = PipelineConfig(prompts=["person"])
         spatial_config = SpatialConfig(
             zones_path=zones_path,
@@ -463,7 +421,7 @@ class TestSpatialPipeline:
 
         input_path = str(tmp_path / "input.mp4")
         output_path = str(tmp_path / "output.mp4")
-        _make_test_video(input_path, num_frames=3)
+        make_test_video(input_path, num_frames=3)
 
         zones_data = {
             "zones": [
@@ -481,8 +439,8 @@ class TestSpatialPipeline:
         with open(zones_path, "w") as f:
             json.dump(zones_data, f)
 
-        dets = self._make_detections(n=1)
-        detector = self._make_mock_detector(dets)
+        dets = make_detections(n=1)
+        detector = make_mock_detector(dets)
         config = PipelineConfig(prompts=["person"])
         spatial_config = SpatialConfig(
             zones_path=zones_path,
@@ -500,7 +458,7 @@ class TestSpatialPipeline:
 
         input_path = str(tmp_path / "input.mp4")
         output_path = str(tmp_path / "output.mp4")
-        _make_test_video(input_path, num_frames=3)
+        make_test_video(input_path, num_frames=3)
 
         call_count = 0
 
@@ -509,7 +467,7 @@ class TestSpatialPipeline:
             call_count += 1
             raise RuntimeError("callback boom")
 
-        detector = self._make_mock_detector()
+        detector = make_mock_detector()
         config = PipelineConfig(prompts=["person"])
         spatial_config = SpatialConfig()
         pipeline = SpatialPipeline(detector, config, spatial_config)
@@ -525,9 +483,9 @@ class TestSpatialPipeline:
         input_path = str(tmp_path / "input.mp4")
         output_path = str(tmp_path / "output.mp4")
         json_path = str(tmp_path / "results.json")
-        _make_test_video(input_path, num_frames=3)
+        make_test_video(input_path, num_frames=3)
 
-        detector = self._make_mock_detector()
+        detector = make_mock_detector()
         config = PipelineConfig(prompts=["person"])
         spatial_config = SpatialConfig()
         pipeline = SpatialPipeline(detector, config, spatial_config)
@@ -542,9 +500,9 @@ class TestSpatialPipeline:
 
         input_path = str(tmp_path / "input.mp4")
         output_path = str(tmp_path / "output.mp4")
-        _make_test_video(input_path, num_frames=3)
+        make_test_video(input_path, num_frames=3)
 
-        detector = self._make_mock_detector()
+        detector = make_mock_detector()
         detector.detect.side_effect = ValueError("model OOM")
         config = PipelineConfig(prompts=["person"])
         spatial_config = SpatialConfig()
@@ -557,7 +515,7 @@ class TestSpatialPipeline:
     def test_invalid_inline_rule_no_conditions_raises(self, tmp_path):
         from dino.spatial.spatial_pipeline import SpatialPipeline
 
-        detector = self._make_mock_detector()
+        detector = make_mock_detector()
         config = PipelineConfig(prompts=["person"])
         spatial_config = SpatialConfig(
             rules=[{"event_type": "bad_rule"}],
@@ -572,9 +530,9 @@ class TestSpatialPipeline:
         output_path = str(tmp_path / "output.mp4")
         json_path = str(tmp_path / "results.json")
         num_frames = 5
-        _make_test_video(input_path, num_frames=num_frames, fps=30)
+        make_test_video(input_path, num_frames=num_frames, fps=30)
 
-        detector = self._make_mock_detector()
+        detector = make_mock_detector()
         config = PipelineConfig(prompts=["person"])
         spatial_config = SpatialConfig()
         pipeline = SpatialPipeline(detector, config, spatial_config)
@@ -596,6 +554,8 @@ class TestSpatialPipeline:
         assert m["fps"] == 30.0
         assert m["total_frames"] == num_frames
         assert m["stride"] == 1
+        # Verify computed values
+        assert data["metadata"]["duration_sec"] == pytest.approx(5 / 30, abs=0.01)
 
     def test_json_export_has_zones(self, tmp_path):
         from dino.spatial.spatial_pipeline import SpatialPipeline
@@ -603,7 +563,7 @@ class TestSpatialPipeline:
         input_path = str(tmp_path / "input.mp4")
         output_path = str(tmp_path / "output.mp4")
         json_path = str(tmp_path / "results.json")
-        _make_test_video(input_path, num_frames=5)
+        make_test_video(input_path, num_frames=5)
 
         zones_data = {
             "zones": [
@@ -621,8 +581,8 @@ class TestSpatialPipeline:
         with open(zones_path, "w") as f:
             json.dump(zones_data, f)
 
-        dets = self._make_detections(n=1)
-        detector = self._make_mock_detector(dets)
+        dets = make_detections(n=1)
+        detector = make_mock_detector(dets)
         config = PipelineConfig(prompts=["person"])
         spatial_config = SpatialConfig(zones_path=zones_path)
         pipeline = SpatialPipeline(detector, config, spatial_config)
@@ -647,9 +607,9 @@ class TestSpatialPipeline:
         output_path = str(tmp_path / "output.mp4")
         json_path = str(tmp_path / "results.json")
         num_frames = 5
-        _make_test_video(input_path, num_frames=num_frames, fps=30)
+        make_test_video(input_path, num_frames=num_frames, fps=30)
 
-        detector = self._make_mock_detector()
+        detector = make_mock_detector()
         config = PipelineConfig(prompts=["person"])
         spatial_config = SpatialConfig()
         pipeline = SpatialPipeline(detector, config, spatial_config)

--- a/tests/test_spatial_pipeline.py
+++ b/tests/test_spatial_pipeline.py
@@ -600,6 +600,29 @@ class TestSpatialPipeline:
         assert isinstance(z["polygon"], list)
         assert all(len(pt) == 2 for pt in z["polygon"])
 
+    def test_json_export_metadata_with_stride(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        json_path = str(tmp_path / "results.json")
+        make_test_video(input_path, num_frames=9)
+
+        detector = make_mock_detector()
+        config = PipelineConfig(prompts=["person"], stride=3)
+        spatial_config = SpatialConfig()
+        pipeline = SpatialPipeline(detector, config, spatial_config)
+        pipeline.run(input_path, output_path, json_output=json_path)
+
+        with open(json_path) as f:
+            data = json.load(f)
+
+        m = data["metadata"]
+        assert m["stride"] == 3
+        assert m["fps"] == 10.0  # 30 / 3
+        assert m["total_frames"] == 3  # ceil(9/3)
+        assert m["duration_sec"] == pytest.approx(3 / 10, abs=0.01)  # 0.3
+
     def test_json_export_metadata_without_zones(self, tmp_path):
         from dino.spatial.spatial_pipeline import SpatialPipeline
 

--- a/tests/test_viewer_data.py
+++ b/tests/test_viewer_data.py
@@ -3,45 +3,8 @@ from __future__ import annotations
 
 import json
 
-import cv2
-import numpy as np
-import pytest
-import supervision as sv
-from unittest.mock import MagicMock
-
+from tests.helpers import make_test_video, make_mock_detector, make_detections
 from dino.config import PipelineConfig, SpatialConfig
-
-
-def _make_test_video(path: str, num_frames: int = 10, fps: int = 30):
-    h, w = 240, 320
-    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
-    writer = cv2.VideoWriter(path, fourcc, fps, (w, h))
-    if not writer.isOpened():
-        raise RuntimeError(f"Failed to open VideoWriter at {path}")
-    for i in range(num_frames):
-        frame = np.zeros((h, w, 3), dtype=np.uint8)
-        frame[:] = (i * 25, i * 10, 0)
-        writer.write(frame)
-    writer.release()
-
-
-def _make_mock_detector(detections=None):
-    detector = MagicMock()
-    if detections is None:
-        detector.detect.return_value = sv.Detections.empty()
-    else:
-        detector.detect.return_value = detections
-    return detector
-
-
-def _make_detections(n=1):
-    xyxy = np.array([[50 + i * 10, 50, 90 + i * 10, 90] for i in range(n)], dtype=np.float32)
-    confidence = np.array([0.9] * n, dtype=np.float32)
-    class_id = np.array([0] * n, dtype=int)
-    return sv.Detections(
-        xyxy=xyxy, confidence=confidence, class_id=class_id,
-        data={"class_name": np.array(["person"] * n)},
-    )
 
 
 class TestViewerDataContract:
@@ -53,7 +16,7 @@ class TestViewerDataContract:
         input_path = str(tmp_path / "input.mp4")
         output_path = str(tmp_path / "output.mp4")
         json_path = str(tmp_path / "spatial_results.json")
-        _make_test_video(input_path, num_frames=6)
+        make_test_video(input_path, num_frames=6)
 
         zones_data = {
             "zones": [
@@ -70,8 +33,8 @@ class TestViewerDataContract:
                 json.dump(zones_data, f)
             spatial_kwargs["zones_path"] = zones_path
 
-        dets = _make_detections(n=2) if with_detections else None
-        detector = _make_mock_detector(dets)
+        dets = make_detections(n=2) if with_detections else None
+        detector = make_mock_detector(dets)
         config = PipelineConfig(prompts=["person"], stride=1)
         spatial_config = SpatialConfig(**spatial_kwargs)
         pipeline = SpatialPipeline(detector, config, spatial_config)

--- a/tests/test_viewer_data.py
+++ b/tests/test_viewer_data.py
@@ -1,0 +1,125 @@
+"""Tests for viewer data contract — validates JSON schema expected by the 3D viewer."""
+from __future__ import annotations
+
+import json
+
+import cv2
+import numpy as np
+import pytest
+import supervision as sv
+from unittest.mock import MagicMock
+
+from dino.config import PipelineConfig, SpatialConfig
+
+
+def _make_test_video(path: str, num_frames: int = 10, fps: int = 30):
+    h, w = 240, 320
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(path, fourcc, fps, (w, h))
+    if not writer.isOpened():
+        raise RuntimeError(f"Failed to open VideoWriter at {path}")
+    for i in range(num_frames):
+        frame = np.zeros((h, w, 3), dtype=np.uint8)
+        frame[:] = (i * 25, i * 10, 0)
+        writer.write(frame)
+    writer.release()
+
+
+def _make_mock_detector(detections=None):
+    detector = MagicMock()
+    if detections is None:
+        detector.detect.return_value = sv.Detections.empty()
+    else:
+        detector.detect.return_value = detections
+    return detector
+
+
+def _make_detections(n=1):
+    xyxy = np.array([[50 + i * 10, 50, 90 + i * 10, 90] for i in range(n)], dtype=np.float32)
+    confidence = np.array([0.9] * n, dtype=np.float32)
+    class_id = np.array([0] * n, dtype=int)
+    return sv.Detections(
+        xyxy=xyxy, confidence=confidence, class_id=class_id,
+        data={"class_name": np.array(["person"] * n)},
+    )
+
+
+class TestViewerDataContract:
+    """Validate the full JSON schema the viewer JS app expects."""
+
+    def _generate_json(self, tmp_path, with_zones=True, with_detections=True):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        json_path = str(tmp_path / "spatial_results.json")
+        _make_test_video(input_path, num_frames=6)
+
+        zones_data = {
+            "zones": [
+                {"zone_id": "z1", "name": "Zone 1", "polygon": [[0, 0], [200, 0], [200, 200], [0, 200]]},
+                {"zone_id": "z2", "name": "Zone 2", "polygon": [[100, 100], [300, 100], [300, 230], [100, 230]]},
+            ],
+            "rules": [{"event_type": "occupied", "requires_any": ["person"]}],
+        }
+
+        spatial_kwargs = {}
+        if with_zones:
+            zones_path = str(tmp_path / "zones.json")
+            with open(zones_path, "w") as f:
+                json.dump(zones_data, f)
+            spatial_kwargs["zones_path"] = zones_path
+
+        dets = _make_detections(n=2) if with_detections else None
+        detector = _make_mock_detector(dets)
+        config = PipelineConfig(prompts=["person"], stride=1)
+        spatial_config = SpatialConfig(**spatial_kwargs)
+        pipeline = SpatialPipeline(detector, config, spatial_config)
+        pipeline.run(input_path, output_path, json_output=json_path)
+
+        with open(json_path) as f:
+            return json.load(f)
+
+    def test_full_schema_keys(self, tmp_path):
+        data = self._generate_json(tmp_path)
+        assert set(data.keys()) == {"metadata", "zones", "frames", "observations", "events"}
+
+    def test_metadata_types(self, tmp_path):
+        data = self._generate_json(tmp_path)
+        m = data["metadata"]
+        assert isinstance(m["fps"], (int, float))
+        assert isinstance(m["width"], int)
+        assert isinstance(m["height"], int)
+        assert isinstance(m["total_frames"], int)
+        assert isinstance(m["duration_sec"], (int, float))
+        assert isinstance(m["stride"], int)
+
+    def test_zones_serialization(self, tmp_path):
+        data = self._generate_json(tmp_path)
+        assert len(data["zones"]) == 2
+        for z in data["zones"]:
+            assert isinstance(z["zone_id"], str)
+            assert isinstance(z["name"], str)
+            assert isinstance(z["polygon"], list)
+            assert all(len(pt) == 2 for pt in z["polygon"])
+
+    def test_frame_objects_have_world_position(self, tmp_path):
+        data = self._generate_json(tmp_path)
+        assert len(data["frames"]) > 0
+        frame = data["frames"][0]
+        assert len(frame["objects"]) > 0
+        for obj in frame["objects"]:
+            wp = obj["world_position"]
+            assert isinstance(wp, list)
+            assert len(wp) == 3
+            assert all(isinstance(v, (int, float)) for v in wp)
+
+    def test_coordinate_space_consistency(self, tmp_path):
+        data = self._generate_json(tmp_path)
+        w, h = data["metadata"]["width"], data["metadata"]["height"]
+        for frame in data["frames"]:
+            for obj in frame["objects"]:
+                wp = obj["world_position"]
+                # World positions should be within reasonable bounds of video dimensions
+                assert -w <= wp[0] <= w * 2, f"x={wp[0]} out of range for width={w}"
+                assert -h <= wp[1] <= h * 2, f"y={wp[1]} out of range for height={h}"

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>DINO 3D Spatial Viewer</title>
+  <link rel="stylesheet" href="style.css">
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/"
+    }
+  }
+  </script>
+</head>
+<body>
+  <div id="app">
+    <header id="toolbar">
+      <h1>DINO Spatial Viewer</h1>
+      <label class="file-input-label">
+        Load JSON
+        <input type="file" id="file-input" accept=".json" />
+      </label>
+      <span id="status">No data loaded</span>
+    </header>
+    <main id="scene-container"></main>
+    <footer id="timeline-bar">
+      <button id="step-back" title="Step back">&lt;&lt;</button>
+      <button id="play-pause" title="Play/Pause">&#9654;</button>
+      <button id="step-forward" title="Step forward">&gt;&gt;</button>
+      <input type="range" id="scrubber" min="0" max="0" value="0" />
+      <span id="time-display">00:00 / 00:00</span>
+      <select id="speed-select">
+        <option value="0.5">0.5x</option>
+        <option value="1" selected>1x</option>
+        <option value="2">2x</option>
+        <option value="4">4x</option>
+      </select>
+      <span id="event-count">Events: 0</span>
+    </footer>
+  </div>
+  <script type="module" src="js/app.js"></script>
+</body>
+</html>

--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -12,93 +12,106 @@ const PLAY_SYMBOL = '\u25B6';
 const PAUSE_SYMBOL = '\u23F8';
 
 let timeline = null;
+let stopRenderLoop = null;
+let abortController = null;
 
 function initViewer(data) {
-  const metadata = getMetadata(data);
-  const zones = getZones(data);
-  const frameIndex = buildFrameIndex(data);
-
-  const container = document.getElementById('scene-container');
-  const { scene, camera, renderer, controls, labelRenderer } = createScene(
-    container, metadata.width, metadata.height
-  );
-
-  createFloorPlan(scene, metadata.width, metadata.height);
-
-  const zoneRenderer = new ZoneRenderer(scene, metadata.width, metadata.height);
-  zoneRenderer.renderZones(zones);
-
-  const objectRenderer = new ObjectRenderer(scene, metadata.width, metadata.height);
-
-  // UI elements
-  const scrubber = document.getElementById('scrubber');
-  const timeDisplay = document.getElementById('time-display');
-  const playPauseBtn = document.getElementById('play-pause');
-  const stepBackBtn = document.getElementById('step-back');
-  const stepForwardBtn = document.getElementById('step-forward');
-  const speedSelect = document.getElementById('speed-select');
-  const eventCount = document.getElementById('event-count');
-  const status = document.getElementById('status');
-
-  const totalEvents = data.events ? data.events.length : 0;
-
-  function updatePlayPauseButton() {
-    playPauseBtn.textContent = timeline.isPlaying ? PAUSE_SYMBOL : PLAY_SYMBOL;
-  }
-
-  // Frame change handler
-  function onFrameChange(frameIdx, frameData) {
-    objectRenderer.updateObjects(frameData ? frameData.objects : null);
-    zoneRenderer.updateFromFrame(frameData);
-    timeDisplay.textContent = timeline.getTimeString();
-    scrubber.value = timeline.currentKeyIndex;
-
-    // Count events up to current frame
-    let eventsToFrame = 0;
-    if (data.events) {
-      for (const e of data.events) {
-        if (e.frame_idx <= frameIdx) eventsToFrame++;
-      }
-    }
-    eventCount.textContent = `Events: ${eventsToFrame} / ${totalEvents}`;
-  }
-
-  // Create timeline
+  // Cleanup previous state
   if (timeline) timeline.destroy();
-  timeline = new Timeline(metadata, frameIndex, onFrameChange);
+  if (stopRenderLoop) stopRenderLoop();
+  if (abortController) abortController.abort();
+  abortController = new AbortController();
+  const signal = abortController.signal;
 
-  // Set up scrubber
-  scrubber.max = timeline.frameKeys.length - 1;
-  scrubber.value = 0;
-  scrubber.addEventListener('input', () => {
-    timeline.seekToKeyIndex(parseInt(scrubber.value, 10));
-  });
+  try {
+    const metadata = getMetadata(data);
+    const zones = getZones(data);
+    const frameIndex = buildFrameIndex(data);
 
-  // Controls
-  playPauseBtn.addEventListener('click', () => {
-    timeline.togglePlayPause();
-    updatePlayPauseButton();
-  });
-  stepBackBtn.addEventListener('click', () => timeline.step(-1));
-  stepForwardBtn.addEventListener('click', () => timeline.step(1));
-  speedSelect.addEventListener('change', () => {
-    timeline.setSpeed(parseFloat(speedSelect.value));
-  });
+    const container = document.getElementById('scene-container');
+    const { scene, camera, renderer, controls, labelRenderer } = createScene(
+      container, metadata.width, metadata.height, signal
+    );
 
-  // Keyboard shortcuts
-  document.addEventListener('keydown', (e) => {
-    if (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT') return;
-    if (e.code === 'Space') { e.preventDefault(); timeline.togglePlayPause(); updatePlayPauseButton(); }
-    if (e.code === 'ArrowLeft') timeline.step(-1);
-    if (e.code === 'ArrowRight') timeline.step(1);
-  });
+    createFloorPlan(scene, metadata.width, metadata.height);
 
-  status.textContent = `Loaded: ${metadata.total_frames} frames, ${zones.length} zones, ${totalEvents} events`;
+    const zoneRenderer = new ZoneRenderer(scene, metadata.width, metadata.height);
+    zoneRenderer.renderZones(zones);
 
-  // Trigger initial frame
-  timeline.seekToKeyIndex(0);
+    const objectRenderer = new ObjectRenderer(scene, metadata.width, metadata.height);
 
-  startRenderLoop(scene, camera, renderer, controls, labelRenderer);
+    // UI elements
+    const scrubber = document.getElementById('scrubber');
+    const timeDisplay = document.getElementById('time-display');
+    const playPauseBtn = document.getElementById('play-pause');
+    const stepBackBtn = document.getElementById('step-back');
+    const stepForwardBtn = document.getElementById('step-forward');
+    const speedSelect = document.getElementById('speed-select');
+    const eventCount = document.getElementById('event-count');
+    const status = document.getElementById('status');
+
+    const totalEvents = data.events ? data.events.length : 0;
+
+    function updatePlayPauseButton() {
+      playPauseBtn.textContent = timeline.isPlaying ? PAUSE_SYMBOL : PLAY_SYMBOL;
+    }
+
+    // Frame change handler
+    function onFrameChange(frameIdx, frameData) {
+      objectRenderer.updateObjects(frameData ? frameData.objects : null);
+      zoneRenderer.updateFromFrame(frameData);
+      timeDisplay.textContent = timeline.getTimeString();
+      scrubber.value = timeline.currentKeyIndex;
+
+      // Count events up to current frame
+      let eventsToFrame = 0;
+      if (data.events) {
+        for (const e of data.events) {
+          if (e.frame_idx <= frameIdx) eventsToFrame++;
+        }
+      }
+      eventCount.textContent = `Events: ${eventsToFrame} / ${totalEvents}`;
+    }
+
+    // Create timeline
+    timeline = new Timeline(metadata, frameIndex, onFrameChange);
+
+    // Set up scrubber
+    scrubber.max = timeline.frameKeys.length - 1;
+    scrubber.value = 0;
+    scrubber.addEventListener('input', () => {
+      timeline.seekToKeyIndex(parseInt(scrubber.value, 10));
+    }, { signal });
+
+    // Controls
+    playPauseBtn.addEventListener('click', () => {
+      timeline.togglePlayPause();
+      updatePlayPauseButton();
+    }, { signal });
+    stepBackBtn.addEventListener('click', () => timeline.step(-1), { signal });
+    stepForwardBtn.addEventListener('click', () => timeline.step(1), { signal });
+    speedSelect.addEventListener('change', () => {
+      timeline.setSpeed(parseFloat(speedSelect.value));
+    }, { signal });
+
+    // Keyboard shortcuts
+    document.addEventListener('keydown', (e) => {
+      if (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT') return;
+      if (e.code === 'Space') { e.preventDefault(); timeline.togglePlayPause(); updatePlayPauseButton(); }
+      if (e.code === 'ArrowLeft') timeline.step(-1);
+      if (e.code === 'ArrowRight') timeline.step(1);
+    }, { signal });
+
+    status.textContent = `Loaded: ${metadata.total_frames} frames, ${zones.length} zones, ${totalEvents} events`;
+
+    // Trigger initial frame
+    timeline.seekToKeyIndex(0);
+
+    stopRenderLoop = startRenderLoop(scene, camera, renderer, controls, labelRenderer);
+  } catch (err) {
+    console.error('Failed to initialize viewer:', err);
+    document.getElementById('status').textContent = `Error: ${err.message}`;
+  }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -118,7 +131,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // Try auto-loading spatial_results.json
   loadData('spatial_results.json')
     .then(data => initViewer(data))
-    .catch(() => {
-      console.log('No spatial_results.json found — use file input to load data.');
+    .catch(err => {
+      console.log('Auto-load spatial_results.json skipped:', err.message);
     });
 });

--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -14,12 +14,21 @@ const PAUSE_SYMBOL = '\u23F8';
 let timeline = null;
 let stopRenderLoop = null;
 let abortController = null;
+let currentRenderer = null;
+let currentLabelRenderer = null;
 
 function initViewer(data) {
   // Cleanup previous state
   if (timeline) timeline.destroy();
   if (stopRenderLoop) stopRenderLoop();
   if (abortController) abortController.abort();
+  if (currentRenderer) {
+    currentRenderer.dispose();
+    currentRenderer.domElement.remove();
+  }
+  if (currentLabelRenderer) {
+    currentLabelRenderer.domElement.remove();
+  }
   abortController = new AbortController();
   const signal = abortController.signal;
 
@@ -32,6 +41,9 @@ function initViewer(data) {
     const { scene, camera, renderer, controls, labelRenderer } = createScene(
       container, metadata.width, metadata.height, signal
     );
+
+    currentRenderer = renderer;
+    currentLabelRenderer = labelRenderer;
 
     createFloorPlan(scene, metadata.width, metadata.height);
 

--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -1,0 +1,124 @@
+/**
+ * Main entry point for the DINO 3D Spatial Viewer.
+ */
+import { loadData, buildFrameIndex, getMetadata, getZones } from './data-loader.js';
+import { createScene, startRenderLoop } from './scene.js';
+import { createFloorPlan } from './floor-plan.js';
+import { ZoneRenderer } from './zone-renderer.js';
+import { ObjectRenderer } from './object-renderer.js';
+import { Timeline } from './timeline.js';
+
+const PLAY_SYMBOL = '\u25B6';
+const PAUSE_SYMBOL = '\u23F8';
+
+let timeline = null;
+
+function initViewer(data) {
+  const metadata = getMetadata(data);
+  const zones = getZones(data);
+  const frameIndex = buildFrameIndex(data);
+
+  const container = document.getElementById('scene-container');
+  const { scene, camera, renderer, controls, labelRenderer } = createScene(
+    container, metadata.width, metadata.height
+  );
+
+  createFloorPlan(scene, metadata.width, metadata.height);
+
+  const zoneRenderer = new ZoneRenderer(scene, metadata.width, metadata.height);
+  zoneRenderer.renderZones(zones);
+
+  const objectRenderer = new ObjectRenderer(scene, metadata.width, metadata.height);
+
+  // UI elements
+  const scrubber = document.getElementById('scrubber');
+  const timeDisplay = document.getElementById('time-display');
+  const playPauseBtn = document.getElementById('play-pause');
+  const stepBackBtn = document.getElementById('step-back');
+  const stepForwardBtn = document.getElementById('step-forward');
+  const speedSelect = document.getElementById('speed-select');
+  const eventCount = document.getElementById('event-count');
+  const status = document.getElementById('status');
+
+  const totalEvents = data.events ? data.events.length : 0;
+
+  function updatePlayPauseButton() {
+    playPauseBtn.textContent = timeline.isPlaying ? PAUSE_SYMBOL : PLAY_SYMBOL;
+  }
+
+  // Frame change handler
+  function onFrameChange(frameIdx, frameData) {
+    objectRenderer.updateObjects(frameData ? frameData.objects : null);
+    zoneRenderer.updateFromFrame(frameData);
+    timeDisplay.textContent = timeline.getTimeString();
+    scrubber.value = timeline.currentKeyIndex;
+
+    // Count events up to current frame
+    let eventsToFrame = 0;
+    if (data.events) {
+      for (const e of data.events) {
+        if (e.frame_idx <= frameIdx) eventsToFrame++;
+      }
+    }
+    eventCount.textContent = `Events: ${eventsToFrame} / ${totalEvents}`;
+  }
+
+  // Create timeline
+  if (timeline) timeline.destroy();
+  timeline = new Timeline(metadata, frameIndex, onFrameChange);
+
+  // Set up scrubber
+  scrubber.max = timeline.frameKeys.length - 1;
+  scrubber.value = 0;
+  scrubber.addEventListener('input', () => {
+    timeline.seekToKeyIndex(parseInt(scrubber.value, 10));
+  });
+
+  // Controls
+  playPauseBtn.addEventListener('click', () => {
+    timeline.togglePlayPause();
+    updatePlayPauseButton();
+  });
+  stepBackBtn.addEventListener('click', () => timeline.step(-1));
+  stepForwardBtn.addEventListener('click', () => timeline.step(1));
+  speedSelect.addEventListener('change', () => {
+    timeline.setSpeed(parseFloat(speedSelect.value));
+  });
+
+  // Keyboard shortcuts
+  document.addEventListener('keydown', (e) => {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT') return;
+    if (e.code === 'Space') { e.preventDefault(); timeline.togglePlayPause(); updatePlayPauseButton(); }
+    if (e.code === 'ArrowLeft') timeline.step(-1);
+    if (e.code === 'ArrowRight') timeline.step(1);
+  });
+
+  status.textContent = `Loaded: ${metadata.total_frames} frames, ${zones.length} zones, ${totalEvents} events`;
+
+  // Trigger initial frame
+  timeline.seekToKeyIndex(0);
+
+  startRenderLoop(scene, camera, renderer, controls, labelRenderer);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  // File input handler
+  document.getElementById('file-input').addEventListener('change', async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    try {
+      const data = await loadData(file);
+      initViewer(data);
+    } catch (err) {
+      console.error('Failed to load file:', err);
+      document.getElementById('status').textContent = `Error: ${err.message}`;
+    }
+  });
+
+  // Try auto-loading spatial_results.json
+  loadData('spatial_results.json')
+    .then(data => initViewer(data))
+    .catch(() => {
+      console.log('No spatial_results.json found — use file input to load data.');
+    });
+});

--- a/viewer/js/data-loader.js
+++ b/viewer/js/data-loader.js
@@ -6,11 +6,19 @@ export async function loadData(source) {
   let data;
   if (source instanceof File) {
     const text = await source.text();
-    data = JSON.parse(text);
+    try {
+      data = JSON.parse(text);
+    } catch (e) {
+      throw new Error(`Failed to parse "${source.name}": ${e.message}`);
+    }
   } else {
     const resp = await fetch(source);
-    if (!resp.ok) throw new Error(`Failed to load: ${resp.status}`);
-    data = await resp.json();
+    if (!resp.ok) throw new Error(`Failed to load ${source}: ${resp.status}`);
+    try {
+      data = await resp.json();
+    } catch (e) {
+      throw new Error(`Failed to parse JSON from ${source}: ${e.message}`);
+    }
   }
   return data;
 }

--- a/viewer/js/data-loader.js
+++ b/viewer/js/data-loader.js
@@ -16,6 +16,9 @@ export async function loadData(source) {
 }
 
 export function buildFrameIndex(data) {
+  if (!Array.isArray(data.frames)) {
+    throw new Error('Invalid data: "frames" must be an array');
+  }
   const index = new Map();
   for (const frame of data.frames) {
     index.set(frame.frame_idx, frame);
@@ -24,6 +27,9 @@ export function buildFrameIndex(data) {
 }
 
 export function getMetadata(data) {
+  if (!data.metadata) {
+    throw new Error('Invalid data: missing "metadata" key');
+  }
   return data.metadata;
 }
 

--- a/viewer/js/data-loader.js
+++ b/viewer/js/data-loader.js
@@ -1,0 +1,32 @@
+/**
+ * Data loading and indexing for the DINO 3D Spatial Viewer.
+ */
+
+export async function loadData(source) {
+  let data;
+  if (source instanceof File) {
+    const text = await source.text();
+    data = JSON.parse(text);
+  } else {
+    const resp = await fetch(source);
+    if (!resp.ok) throw new Error(`Failed to load: ${resp.status}`);
+    data = await resp.json();
+  }
+  return data;
+}
+
+export function buildFrameIndex(data) {
+  const index = new Map();
+  for (const frame of data.frames) {
+    index.set(frame.frame_idx, frame);
+  }
+  return index;
+}
+
+export function getMetadata(data) {
+  return data.metadata;
+}
+
+export function getZones(data) {
+  return data.zones || [];
+}

--- a/viewer/js/floor-plan.js
+++ b/viewer/js/floor-plan.js
@@ -1,0 +1,38 @@
+/**
+ * Floor plan (ground plane) for the DINO 3D Spatial Viewer.
+ */
+import * as THREE from 'three';
+
+/**
+ * Convert pixel coordinates to Three.js world coordinates.
+ * Pixel: origin top-left, X-right, Y-down
+ * Three.js: Y-up, centered at origin
+ */
+export function pixelToWorld(px, py, width, height) {
+  return {
+    x: px - width / 2,
+    y: 0,
+    z: -(py - height / 2),
+  };
+}
+
+export function createFloorPlan(scene, width, height) {
+  // Ground plane
+  const geometry = new THREE.PlaneGeometry(width, height);
+  const material = new THREE.MeshStandardMaterial({
+    color: 0x374151,
+    roughness: 0.9,
+    side: THREE.DoubleSide,
+  });
+  const plane = new THREE.Mesh(geometry, material);
+  plane.rotation.x = -Math.PI / 2;
+  plane.position.y = -0.1;
+  scene.add(plane);
+
+  // Grid
+  const grid = new THREE.GridHelper(Math.max(width, height), 20, 0x475569, 0x334155);
+  grid.position.y = 0;
+  scene.add(grid);
+
+  return plane;
+}

--- a/viewer/js/object-renderer.js
+++ b/viewer/js/object-renderer.js
@@ -1,0 +1,89 @@
+/**
+ * Object rendering with pooled markers for the DINO 3D Spatial Viewer.
+ */
+import * as THREE from 'three';
+import { CSS2DObject } from 'three/addons/renderers/CSS2DRenderer.js';
+import { pixelToWorld } from './floor-plan.js';
+
+const CLASS_COLORS = {
+  person: 0x38bdf8,
+  chair: 0xa78bfa,
+};
+const DEFAULT_COLOR = 0xfb923c;
+const MARKER_RADIUS = 4;
+const MARKER_HEIGHT = 12;
+
+export class ObjectRenderer {
+  constructor(scene, width, height) {
+    this.scene = scene;
+    this.width = width;
+    this.height = height;
+    this.pool = new Map(); // persistent_id -> { mesh, label, group }
+  }
+
+  _getColor(className) {
+    return CLASS_COLORS[className] || DEFAULT_COLOR;
+  }
+
+  _getOrCreateMarker(persistentId, className) {
+    if (this.pool.has(persistentId)) {
+      return this.pool.get(persistentId);
+    }
+
+    const group = new THREE.Group();
+
+    const geometry = new THREE.CylinderGeometry(MARKER_RADIUS, MARKER_RADIUS, MARKER_HEIGHT, 12);
+    const material = new THREE.MeshStandardMaterial({ color: this._getColor(className) });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.y = MARKER_HEIGHT / 2;
+    group.add(mesh);
+
+    const labelDiv = document.createElement('div');
+    labelDiv.style.cssText = 'color: #e2e8f0; font-size: 10px; background: rgba(15,23,42,0.85); padding: 1px 4px; border-radius: 2px; white-space: nowrap;';
+    const label = new CSS2DObject(labelDiv);
+    label.position.set(0, MARKER_HEIGHT + 4, 0);
+    group.add(label);
+
+    this.scene.add(group);
+    const entry = { group, mesh, label, labelDiv, material };
+    this.pool.set(persistentId, entry);
+    return entry;
+  }
+
+  updateObjects(frameObjects) {
+    const seen = new Set();
+
+    if (frameObjects) {
+      for (const obj of frameObjects) {
+        const id = obj.persistent_id;
+        seen.add(id);
+        const entry = this._getOrCreateMarker(id, obj.class_name);
+
+        // Update position from world_position
+        const wp = obj.world_position;
+        const pos = pixelToWorld(wp[0], wp[1], this.width, this.height);
+        entry.group.position.set(pos.x, 0, pos.z);
+        entry.group.visible = true;
+
+        // Update label
+        entry.labelDiv.textContent = `${obj.class_name} #${id}`;
+
+        // Update color in case class changed
+        entry.material.color.setHex(this._getColor(obj.class_name));
+      }
+    }
+
+    // Hide unseen markers
+    for (const [id, entry] of this.pool) {
+      if (!seen.has(id)) {
+        entry.group.visible = false;
+      }
+    }
+  }
+
+  hideAll() {
+    for (const entry of this.pool.values()) {
+      entry.group.visible = false;
+    }
+  }
+}

--- a/viewer/js/object-renderer.js
+++ b/viewer/js/object-renderer.js
@@ -45,7 +45,7 @@ export class ObjectRenderer {
     group.add(label);
 
     this.scene.add(group);
-    const entry = { group, mesh, label, labelDiv, material };
+    const entry = { group, mesh, label, labelDiv, material }; // pool: persistent_id -> { group, mesh, label, labelDiv, material }
     this.pool.set(persistentId, entry);
     return entry;
   }
@@ -55,6 +55,10 @@ export class ObjectRenderer {
 
     if (frameObjects) {
       for (const obj of frameObjects) {
+        if (!obj.world_position || !Array.isArray(obj.world_position) || obj.persistent_id == null) {
+          console.warn('Skipping object with missing data:', obj);
+          continue;
+        }
         const id = obj.persistent_id;
         seen.add(id);
         const entry = this._getOrCreateMarker(id, obj.class_name);

--- a/viewer/js/scene.js
+++ b/viewer/js/scene.js
@@ -5,7 +5,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { CSS2DRenderer } from 'three/addons/renderers/CSS2DRenderer.js';
 
-export function createScene(container, width, height) {
+export function createScene(container, width, height, signal) {
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0x0f172a);
 
@@ -61,17 +61,19 @@ export function createScene(container, width, height) {
     renderer.setSize(w, h);
     labelRenderer.setSize(w, h);
   };
-  window.addEventListener('resize', onResize);
+  window.addEventListener('resize', onResize, { signal });
 
   return { scene, camera, renderer, controls, labelRenderer };
 }
 
 export function startRenderLoop(scene, camera, renderer, controls, labelRenderer) {
+  let rafId = null;
   function animate() {
-    requestAnimationFrame(animate);
+    rafId = requestAnimationFrame(animate);
     controls.update();
     renderer.render(scene, camera);
     labelRenderer.render(scene, camera);
   }
   animate();
+  return () => { if (rafId) cancelAnimationFrame(rafId); };
 }

--- a/viewer/js/scene.js
+++ b/viewer/js/scene.js
@@ -1,0 +1,77 @@
+/**
+ * Three.js scene setup for the DINO 3D Spatial Viewer.
+ */
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { CSS2DRenderer } from 'three/addons/renderers/CSS2DRenderer.js';
+
+export function createScene(container, width, height) {
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x0f172a);
+
+  // Orthographic camera — top-down view
+  const aspect = container.clientWidth / container.clientHeight;
+  const frustumSize = Math.max(width, height) * 0.6;
+  const camera = new THREE.OrthographicCamera(
+    -frustumSize * aspect, frustumSize * aspect,
+    frustumSize, -frustumSize,
+    0.1, 2000
+  );
+  camera.position.set(0, 500, 0);
+  camera.lookAt(0, 0, 0);
+
+  // WebGL renderer
+  const renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setSize(container.clientWidth, container.clientHeight);
+  renderer.setPixelRatio(window.devicePixelRatio);
+  container.appendChild(renderer.domElement);
+
+  // CSS2D renderer for labels
+  const labelRenderer = new CSS2DRenderer();
+  labelRenderer.setSize(container.clientWidth, container.clientHeight);
+  labelRenderer.domElement.style.position = 'absolute';
+  labelRenderer.domElement.style.top = '0';
+  labelRenderer.domElement.style.left = '0';
+  labelRenderer.domElement.style.pointerEvents = 'none';
+  container.appendChild(labelRenderer.domElement);
+
+  // Controls
+  const controls = new OrbitControls(camera, renderer.domElement);
+  controls.enableRotate = true;
+  controls.enablePan = true;
+  controls.enableZoom = true;
+  controls.maxPolarAngle = Math.PI / 2;
+
+  // Lights
+  scene.add(new THREE.AmbientLight(0xffffff, 0.6));
+  const dirLight = new THREE.DirectionalLight(0xffffff, 0.8);
+  dirLight.position.set(100, 300, 100);
+  scene.add(dirLight);
+
+  // Resize handler
+  const onResize = () => {
+    const w = container.clientWidth;
+    const h = container.clientHeight;
+    const a = w / h;
+    camera.left = -frustumSize * a;
+    camera.right = frustumSize * a;
+    camera.top = frustumSize;
+    camera.bottom = -frustumSize;
+    camera.updateProjectionMatrix();
+    renderer.setSize(w, h);
+    labelRenderer.setSize(w, h);
+  };
+  window.addEventListener('resize', onResize);
+
+  return { scene, camera, renderer, controls, labelRenderer };
+}
+
+export function startRenderLoop(scene, camera, renderer, controls, labelRenderer) {
+  function animate() {
+    requestAnimationFrame(animate);
+    controls.update();
+    renderer.render(scene, camera);
+    labelRenderer.render(scene, camera);
+  }
+  animate();
+}

--- a/viewer/js/timeline.js
+++ b/viewer/js/timeline.js
@@ -1,0 +1,125 @@
+/**
+ * Playback timeline engine for the DINO 3D Spatial Viewer.
+ */
+
+export class Timeline {
+  constructor(metadata, frameIndex, onFrameChange) {
+    this.fps = metadata.fps;
+    this.totalFrames = metadata.total_frames;
+    this.duration = metadata.duration_sec;
+    this.frameIndex = frameIndex;
+    this.onFrameChange = onFrameChange;
+
+    // Build sorted frame list from the frame index keys
+    this.frameKeys = Array.from(frameIndex.keys()).sort((a, b) => a - b);
+    this.currentKeyIndex = 0;
+
+    this.isPlaying = false;
+    this.speed = 1;
+    this._rafId = null;
+    this._lastTime = null;
+    this._accumulator = 0;
+  }
+
+  get currentFrame() {
+    return this.frameKeys[this.currentKeyIndex] ?? 0;
+  }
+
+  play() {
+    if (this.isPlaying) return;
+    this.isPlaying = true;
+    this._lastTime = performance.now();
+    this._accumulator = 0;
+    this._tick();
+  }
+
+  pause() {
+    this.isPlaying = false;
+    if (this._rafId) {
+      cancelAnimationFrame(this._rafId);
+      this._rafId = null;
+    }
+  }
+
+  togglePlayPause() {
+    this.isPlaying ? this.pause() : this.play();
+  }
+
+  setSpeed(multiplier) {
+    this.speed = multiplier;
+  }
+
+  seekTo(frameIdx) {
+    // Find closest key index
+    const idx = this.frameKeys.indexOf(frameIdx);
+    if (idx >= 0) {
+      this.currentKeyIndex = idx;
+    } else {
+      // Find nearest
+      let closest = 0;
+      for (let i = 0; i < this.frameKeys.length; i++) {
+        if (Math.abs(this.frameKeys[i] - frameIdx) < Math.abs(this.frameKeys[closest] - frameIdx)) {
+          closest = i;
+        }
+      }
+      this.currentKeyIndex = closest;
+    }
+    this._emitFrame();
+  }
+
+  seekToKeyIndex(keyIndex) {
+    this.currentKeyIndex = Math.max(0, Math.min(keyIndex, this.frameKeys.length - 1));
+    this._emitFrame();
+  }
+
+  step(direction) {
+    this.currentKeyIndex = Math.max(0, Math.min(
+      this.currentKeyIndex + direction,
+      this.frameKeys.length - 1
+    ));
+    this._emitFrame();
+  }
+
+  getTimeString() {
+    const current = this.currentFrame / this.fps;
+    return `${this._fmt(current)} / ${this._fmt(this.duration)}`;
+  }
+
+  _fmt(seconds) {
+    const m = Math.floor(seconds / 60);
+    const s = Math.floor(seconds % 60);
+    return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  }
+
+  _tick() {
+    if (!this.isPlaying) return;
+    this._rafId = requestAnimationFrame((now) => {
+      const delta = (now - this._lastTime) / 1000;
+      this._lastTime = now;
+      this._accumulator += delta * this.speed;
+
+      const frameInterval = 1 / this.fps;
+      while (this._accumulator >= frameInterval) {
+        this._accumulator -= frameInterval;
+        if (this.currentKeyIndex < this.frameKeys.length - 1) {
+          this.currentKeyIndex++;
+        } else {
+          // Loop back to start
+          this.currentKeyIndex = 0;
+        }
+      }
+      this._emitFrame();
+      this._tick();
+    });
+  }
+
+  _emitFrame() {
+    const frameIdx = this.frameKeys[this.currentKeyIndex];
+    const frameData = this.frameIndex.get(frameIdx);
+    this.onFrameChange(frameIdx, frameData);
+  }
+
+  destroy() {
+    this.pause();
+  }
+}

--- a/viewer/js/timeline.js
+++ b/viewer/js/timeline.js
@@ -5,6 +5,7 @@
 export class Timeline {
   constructor(metadata, frameIndex, onFrameChange) {
     this.fps = metadata.fps;
+    this.stride = metadata.stride || 1;
     this.totalFrames = metadata.total_frames;
     this.duration = metadata.duration_sec;
     this.frameIndex = frameIndex;
@@ -81,7 +82,8 @@ export class Timeline {
   }
 
   getTimeString() {
-    const current = this.currentFrame / this.fps;
+    const originalFps = this.fps * this.stride;
+    const current = this.currentFrame / originalFps;
     return `${this._fmt(current)} / ${this._fmt(this.duration)}`;
   }
 

--- a/viewer/js/zone-renderer.js
+++ b/viewer/js/zone-renderer.js
@@ -1,0 +1,92 @@
+/**
+ * Zone rendering as 3D extruded volumes for the DINO 3D Spatial Viewer.
+ */
+import * as THREE from 'three';
+import { CSS2DObject } from 'three/addons/renderers/CSS2DRenderer.js';
+import { pixelToWorld } from './floor-plan.js';
+
+const ZONE_INACTIVE_COLOR = 0x22c55e;
+const ZONE_ACTIVE_COLOR = 0xf97316;
+const ZONE_HEIGHT = 8;
+const ZONE_OPACITY = 0.3;
+
+export class ZoneRenderer {
+  constructor(scene, width, height) {
+    this.scene = scene;
+    this.width = width;
+    this.height = height;
+    this.zones = new Map();
+  }
+
+  renderZones(zoneDefs) {
+    for (const z of zoneDefs) {
+      const shape = new THREE.Shape();
+      const points = z.polygon.map(([px, py]) => pixelToWorld(px, py, this.width, this.height));
+
+      shape.moveTo(points[0].x, points[0].z);
+      for (let i = 1; i < points.length; i++) {
+        shape.lineTo(points[i].x, points[i].z);
+      }
+      shape.closePath();
+
+      // Extruded volume
+      const extrudeSettings = { depth: ZONE_HEIGHT, bevelEnabled: false };
+      const geometry = new THREE.ExtrudeGeometry(shape, extrudeSettings);
+      geometry.rotateX(-Math.PI / 2);
+
+      const material = new THREE.MeshStandardMaterial({
+        color: ZONE_INACTIVE_COLOR,
+        transparent: true,
+        opacity: ZONE_OPACITY,
+        side: THREE.DoubleSide,
+      });
+      const mesh = new THREE.Mesh(geometry, material);
+      mesh.position.y = 0;
+      this.scene.add(mesh);
+
+      // Wireframe
+      const edges = new THREE.EdgesGeometry(geometry);
+      const wireframe = new THREE.LineSegments(
+        edges,
+        new THREE.LineBasicMaterial({ color: ZONE_INACTIVE_COLOR, opacity: 0.8, transparent: true })
+      );
+      wireframe.position.copy(mesh.position);
+      this.scene.add(wireframe);
+
+      // Label
+      const labelDiv = document.createElement('div');
+      labelDiv.textContent = z.name;
+      labelDiv.style.cssText = 'color: #e2e8f0; font-size: 12px; font-weight: 600; background: rgba(30,41,59,0.8); padding: 2px 6px; border-radius: 3px;';
+      const label = new CSS2DObject(labelDiv);
+
+      // Position label at centroid
+      const cx = points.reduce((s, p) => s + p.x, 0) / points.length;
+      const cz = points.reduce((s, p) => s + p.z, 0) / points.length;
+      label.position.set(cx, ZONE_HEIGHT + 2, cz);
+      this.scene.add(label);
+
+      this.zones.set(z.zone_id, { mesh, wireframe, label, material });
+    }
+  }
+
+  setZoneActive(zoneId, active) {
+    const entry = this.zones.get(zoneId);
+    if (!entry) return;
+    const color = active ? ZONE_ACTIVE_COLOR : ZONE_INACTIVE_COLOR;
+    entry.material.color.setHex(color);
+    entry.wireframe.material.color.setHex(color);
+  }
+
+  updateFromFrame(frameData) {
+    // Determine which zones have objects present
+    const activeZones = new Set();
+    if (frameData && frameData.objects) {
+      for (const obj of frameData.objects) {
+        if (obj.zone_id) activeZones.add(obj.zone_id);
+      }
+    }
+    for (const zoneId of this.zones.keys()) {
+      this.setZoneActive(zoneId, activeZones.has(zoneId));
+    }
+  }
+}

--- a/viewer/js/zone-renderer.js
+++ b/viewer/js/zone-renderer.js
@@ -20,6 +20,10 @@ export class ZoneRenderer {
 
   renderZones(zoneDefs) {
     for (const z of zoneDefs) {
+      if (!z.polygon || !Array.isArray(z.polygon) || z.polygon.length < 3) {
+        console.warn(`Skipping zone "${z.zone_id}": invalid polygon`);
+        continue;
+      }
       const shape = new THREE.Shape();
       const points = z.polygon.map(([px, py]) => pixelToWorld(px, py, this.width, this.height));
 

--- a/viewer/serve.py
+++ b/viewer/serve.py
@@ -11,7 +11,7 @@ def main():
     args = parser.parse_args()
 
     handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=".")
-    with http.server.HTTPServer(("", args.port), handler) as httpd:
+    with http.server.HTTPServer(("127.0.0.1", args.port), handler) as httpd:
         print(f"DINO Viewer serving at http://localhost:{args.port}")
         print("Press Ctrl+C to stop")
         httpd.serve_forever()

--- a/viewer/serve.py
+++ b/viewer/serve.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Simple HTTP server for the DINO 3D Spatial Viewer."""
+import argparse
+import http.server
+import functools
+
+
+def main():
+    parser = argparse.ArgumentParser(description="DINO Viewer dev server")
+    parser.add_argument("--port", type=int, default=8080)
+    args = parser.parse_args()
+
+    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=".")
+    with http.server.HTTPServer(("", args.port), handler) as httpd:
+        print(f"DINO Viewer serving at http://localhost:{args.port}")
+        print("Press Ctrl+C to stop")
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -1,0 +1,95 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: #0f172a;
+  color: #e2e8f0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+#app {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  height: 100vh;
+}
+
+#toolbar {
+  background: #1e293b;
+  padding: 8px 16px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+h1 {
+  color: #38bdf8;
+  font-size: 1.2rem;
+  margin: 0;
+}
+
+#scene-container {
+  position: relative;
+  overflow: hidden;
+}
+
+#timeline-bar {
+  background: #1e293b;
+  padding: 8px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+button {
+  background: #334155;
+  color: #e2e8f0;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #475569;
+}
+
+#scrubber {
+  flex: 1;
+  accent-color: #38bdf8;
+}
+
+#speed-select {
+  background: #334155;
+  color: #e2e8f0;
+  border: 1px solid #475569;
+  border-radius: 4px;
+  padding: 4px;
+}
+
+#status {
+  color: #94a3b8;
+  margin-left: auto;
+}
+
+.file-input-label {
+  background: #38bdf8;
+  color: #0f172a;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.file-input-label input {
+  display: none;
+}
+
+#time-display,
+#event-count {
+  color: #94a3b8;
+  font-family: monospace;
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Summary

- Enrich JSON export with `metadata` (fps, width, height, total_frames, duration_sec, stride) and `zones` (serialized zone definitions) — backward-compatible
- Add standalone Three.js web viewer (`viewer/`) with 3D scene, zone volumes, object markers, and timeline playback
- Add tests for enriched export and viewer data contract

## Changes

### Python backend
- `src/dino/spatial/spatial_pipeline.py` — add `metadata` and `zones` keys to JSON export

### Tests
- `tests/test_spatial_pipeline.py` — 3 new tests: metadata, zones, metadata-without-zones
- `tests/test_viewer_data.py` — 5 contract tests validating full viewer JSON schema

### Web viewer (`viewer/`)
- `index.html` — layout shell with Three.js import map
- `style.css` — dark theme (#0f172a bg, #38bdf8 accent)
- `serve.py` — dev HTTP server
- `js/data-loader.js` — JSON loading + frame indexing
- `js/scene.js` — Three.js scene, orthographic camera, orbit controls
- `js/floor-plan.js` — ground plane + coordinate mapping
- `js/zone-renderer.js` — 3D extruded zone volumes with labels
- `js/object-renderer.js` — pooled object markers with CSS2D labels
- `js/timeline.js` — play/pause/scrub/speed playback engine
- `js/app.js` — entry point wiring everything together

## Test plan

- [x] `uv run pytest tests/test_spatial_pipeline.py -v` — 32 tests pass
- [x] `uv run pytest tests/test_viewer_data.py -v` — 5 tests pass
- [ ] Manual: generate JSON with `demo_spatial.py`, open viewer, verify 3D scene renders

Fixes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)