### PR TITLE
feat: monocular depth estimation + camera frustum (Phase 4b)

### DIFF
--- a/scripts/demo_spatial.py
+++ b/scripts/demo_spatial.py
@@ -20,7 +20,16 @@ def main():
         "--prompts", nargs="+", required=True, help="Text prompts for detection"
     )
     parser.add_argument(
-        "--camera-mode", default="fixed", choices=["fixed"], help="Camera mode"
+        "--camera-mode", default="fixed", choices=["fixed", "depth"],
+        help="Camera mode ('fixed' for flat 2D, 'depth' for 3D with monocular depth)",
+    )
+    parser.add_argument(
+        "--camera-fov", type=float, default=70.0,
+        help="Camera horizontal FOV in degrees (depth mode only)",
+    )
+    parser.add_argument(
+        "--depth-model", default=None,
+        help="Depth estimation model ID (default: Depth-Anything-V2-Small)",
     )
     parser.add_argument(
         "--stride", type=int, default=1, help="Process every Nth frame"
@@ -47,6 +56,8 @@ def main():
         spatial_config = SpatialConfig(
             camera_mode=args.camera_mode,
             zones_path=args.zones,
+            depth_model=args.depth_model,
+            camera_fov_deg=args.camera_fov,
         )
 
         print("Loading Grounding DINO...")

--- a/src/dino/config.py
+++ b/src/dino/config.py
@@ -29,12 +29,14 @@ class SpatialConfig:
     max_age_seconds: float = 30.0
     zones_path: str | None = None
     rules: list[dict] | None = None
+    depth_model: str | None = None
+    camera_fov_deg: float = 70.0
 
     def __post_init__(self):
-        if self.camera_mode not in ("fixed",):
+        if self.camera_mode not in ("fixed", "depth"):
             raise ValueError(
                 f"Unsupported camera_mode: {self.camera_mode!r}, "
-                f"must be one of ('fixed',)"
+                f"must be one of ('fixed', 'depth')"
             )
         if self.match_distance <= 0:
             raise ValueError(f"match_distance must be > 0, got {self.match_distance}")

--- a/src/dino/spatial/camera_estimator.py
+++ b/src/dino/spatial/camera_estimator.py
@@ -28,6 +28,11 @@ def estimate_camera(
     Returns:
         Tuple of (CameraIntrinsics, CameraPose).
     """
+    if width <= 0 or height <= 0:
+        raise ValueError(f"Video dimensions must be positive, got {width}x{height}")
+    if not (0 < fov_deg < 180):
+        raise ValueError(f"FOV must be between 0 and 180 degrees (exclusive), got {fov_deg}")
+
     fx = fy = width / (2 * math.tan(math.radians(fov_deg / 2)))
     cx, cy = width / 2.0, height / 2.0
     intrinsics = CameraIntrinsics(fx=fx, fy=fy, cx=cx, cy=cy, width=width, height=height)

--- a/src/dino/spatial/camera_estimator.py
+++ b/src/dino/spatial/camera_estimator.py
@@ -1,0 +1,52 @@
+"""Heuristic camera parameter estimation for typical CCTV/overhead cameras."""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from dino.spatial.models import CameraIntrinsics, CameraPose
+
+
+def estimate_camera(
+    width: int,
+    height: int,
+    fov_deg: float = 70.0,
+) -> tuple[CameraIntrinsics, CameraPose]:
+    """Estimate camera intrinsics and pose from video dimensions.
+
+    Assumptions for a typical overhead/CCTV camera:
+    - Horizontal FOV as specified (default 70 degrees)
+    - Camera mounted above the scene, looking down at ~45 degrees
+    - World origin at center of floor plane
+
+    Args:
+        width: Video width in pixels.
+        height: Video height in pixels.
+        fov_deg: Horizontal field of view in degrees.
+
+    Returns:
+        Tuple of (CameraIntrinsics, CameraPose).
+    """
+    fx = fy = width / (2 * math.tan(math.radians(fov_deg / 2)))
+    cx, cy = width / 2.0, height / 2.0
+    intrinsics = CameraIntrinsics(fx=fx, fy=fy, cx=cx, cy=cy, width=width, height=height)
+
+    # Camera at scale-relative height, tilted 45 degrees down
+    cam_height = max(width, height) * 0.8
+    translation = np.array([0.0, cam_height, 0.0])
+
+    angle = math.radians(45)
+    rotation = np.array([
+        [1, 0, 0],
+        [0, math.cos(angle), -math.sin(angle)],
+        [0, math.sin(angle), math.cos(angle)],
+    ])
+
+    pose = CameraPose(
+        translation=translation,
+        rotation=rotation,
+        frame_idx=0,
+    )
+
+    return intrinsics, pose

--- a/src/dino/spatial/depth_estimator.py
+++ b/src/dino/spatial/depth_estimator.py
@@ -32,4 +32,7 @@ class DepthEstimator:
         rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
         result = self._pipe(Image.fromarray(rgb))
         depth = np.array(result["depth"], dtype=np.float32)
-        return depth / 255.0
+        d_min, d_max = depth.min(), depth.max()
+        if d_max - d_min < 1e-8:
+            return np.zeros_like(depth)
+        return (depth - d_min) / (d_max - d_min)

--- a/src/dino/spatial/depth_estimator.py
+++ b/src/dino/spatial/depth_estimator.py
@@ -1,0 +1,35 @@
+"""Monocular depth estimation using Depth Anything v2."""
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from PIL import Image
+from transformers import pipeline
+
+
+class DepthEstimator:
+    """Thin wrapper around transformers depth-estimation pipeline."""
+
+    DEFAULT_MODEL = "depth-anything/Depth-Anything-V2-Small-hf"
+
+    def __init__(
+        self,
+        model_id: str | None = None,
+        device: str = "cpu",
+    ):
+        self._pipe = pipeline(
+            "depth-estimation",
+            model=model_id or self.DEFAULT_MODEL,
+            device=device,
+        )
+
+    def estimate(self, frame_bgr: np.ndarray) -> np.ndarray:
+        """Estimate depth from a BGR frame.
+
+        Returns:
+            HxW float32 depth map normalized to [0, 1].
+        """
+        rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
+        result = self._pipe(Image.fromarray(rgb))
+        depth = np.array(result["depth"], dtype=np.float32)
+        return depth / 255.0

--- a/src/dino/spatial/depth_localizer.py
+++ b/src/dino/spatial/depth_localizer.py
@@ -37,10 +37,13 @@ class DepthLocalizer(BaseLocalizer):
     def localize(
         self, detections: sv.Detections, frame: np.ndarray, frame_idx: int
     ) -> list[WorldObject]:
+        if len(detections) == 0:
+            return []
+
         depth_map = self._depth.estimate(frame)
         h, w = depth_map.shape
 
-        if detections.tracker_id is None and len(detections) > 0:
+        if detections.tracker_id is None:
             logger.warning(
                 "Detections have no tracker_id — all %d objects will get "
                 "tracker_id=-1, which causes identity collision in the registry.",

--- a/src/dino/spatial/depth_localizer.py
+++ b/src/dino/spatial/depth_localizer.py
@@ -1,0 +1,96 @@
+"""Depth-based localizer using monocular depth estimation + camera projection."""
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import supervision as sv
+
+from dino.spatial.base_localizer import BaseLocalizer
+from dino.spatial.depth_estimator import DepthEstimator
+from dino.spatial.models import CameraIntrinsics, CameraPose, WorldObject
+from dino.spatial.projection import backproject_to_world
+
+logger = logging.getLogger(__name__)
+
+# Minimum depth value to avoid division-by-zero in backprojection
+_DEPTH_EPSILON = 1e-3
+
+
+class DepthLocalizer(BaseLocalizer):
+    """Localizer that uses monocular depth estimation + camera model.
+
+    Samples depth at the bottom-center of each bounding box (the object's
+    base/feet) and backprojects to 3D world coordinates.
+    """
+
+    def __init__(
+        self,
+        intrinsics: CameraIntrinsics,
+        pose: CameraPose,
+        depth_estimator: DepthEstimator,
+    ):
+        self._intrinsics = intrinsics
+        self._pose = pose
+        self._depth = depth_estimator
+
+    def localize(
+        self, detections: sv.Detections, frame: np.ndarray, frame_idx: int
+    ) -> list[WorldObject]:
+        depth_map = self._depth.estimate(frame)
+        h, w = depth_map.shape
+
+        if detections.tracker_id is None and len(detections) > 0:
+            logger.warning(
+                "Detections have no tracker_id — all %d objects will get "
+                "tracker_id=-1, which causes identity collision in the registry.",
+                len(detections),
+            )
+
+        objects: list[WorldObject] = []
+        for i in range(len(detections)):
+            x1, y1, x2, y2 = detections.xyxy[i]
+
+            # Sample depth at bottom-center of bbox (base of object)
+            u = (x1 + x2) / 2.0
+            v = float(y2)  # bottom of bbox
+
+            depth_val = float(
+                depth_map[min(int(v), h - 1), min(int(u), w - 1)]
+            )
+
+            # Clamp to epsilon to avoid backprojection errors
+            depth_val = max(depth_val, _DEPTH_EPSILON)
+
+            world_pos = backproject_to_world(
+                u, v, depth_val, self._intrinsics, self._pose
+            )
+
+            obj = WorldObject(
+                tracker_id=(
+                    int(detections.tracker_id[i])
+                    if detections.tracker_id is not None
+                    else -1
+                ),
+                bbox_xyxy=detections.xyxy[i].copy(),
+                world_position=world_pos,
+                class_name=(
+                    str(detections.data["class_name"][i])
+                    if "class_name" in detections.data
+                    else ""
+                ),
+                class_id=(
+                    int(detections.class_id[i])
+                    if detections.class_id is not None
+                    else -1
+                ),
+                confidence=(
+                    float(detections.confidence[i])
+                    if detections.confidence is not None
+                    else 0.0
+                ),
+                frame_idx=frame_idx,
+            )
+            objects.append(obj)
+
+        return objects

--- a/src/dino/spatial/spatial_pipeline.py
+++ b/src/dino/spatial/spatial_pipeline.py
@@ -60,8 +60,20 @@ class SpatialPipeline:
         self._zone_annotator = ZoneAnnotator()
 
         # Localizer
+        self._camera_intrinsics = None
+        self._camera_pose = None
+
         if spatial_config.camera_mode == "fixed":
             self._localizer = FixedCameraLocalizer()
+        elif spatial_config.camera_mode == "depth":
+            # Depth localizer needs video dimensions for camera estimation.
+            # We load the model eagerly but defer localizer creation until run().
+            from dino.spatial.depth_estimator import DepthEstimator
+
+            self._depth_estimator = DepthEstimator(
+                model_id=spatial_config.depth_model,
+            )
+            self._localizer = FixedCameraLocalizer()  # placeholder until run()
         else:
             raise ValueError(f"Unsupported camera_mode: {spatial_config.camera_mode!r}")
 
@@ -134,6 +146,20 @@ class SpatialPipeline:
         output_p.parent.mkdir(parents=True, exist_ok=True)
 
         video_info = sv.VideoInfo.from_video_path(input_path)
+
+        # Finalize depth localizer now that we know video dimensions
+        if self.spatial_config.camera_mode == "depth":
+            from dino.spatial.camera_estimator import estimate_camera
+            from dino.spatial.depth_localizer import DepthLocalizer
+
+            intrinsics, pose = estimate_camera(
+                video_info.width, video_info.height,
+                self.spatial_config.camera_fov_deg,
+            )
+            self._localizer = DepthLocalizer(intrinsics, pose, self._depth_estimator)
+            self._camera_intrinsics = intrinsics
+            self._camera_pose = pose
+
         if video_info.fps <= 0:
             raise ValueError(
                 f"Input video reports fps={video_info.fps}. "
@@ -196,6 +222,20 @@ class SpatialPipeline:
             json_path.parent.mkdir(parents=True, exist_ok=True)
             tmp_path = json_path.with_suffix(".json.tmp")
             try:
+                camera_meta = None
+                if self._camera_intrinsics is not None:
+                    ci = self._camera_intrinsics
+                    camera_meta = {
+                        "position": self._camera_pose.translation.tolist(),
+                        "rotation": self._camera_pose.rotation.tolist(),
+                        "fov_deg": self.spatial_config.camera_fov_deg,
+                        "intrinsics": {
+                            "fx": ci.fx, "fy": ci.fy,
+                            "cx": ci.cx, "cy": ci.cy,
+                            "width": ci.width, "height": ci.height,
+                        },
+                    }
+
                 with open(tmp_path, "w") as f:
                     json.dump(
                         {
@@ -206,6 +246,7 @@ class SpatialPipeline:
                                 "total_frames": total_frames,
                                 "duration_sec": round(total_frames / adjusted_fps, 3),
                                 "stride": self.config.stride,
+                                "camera": camera_meta,
                             },
                             "zones": [
                                 {"zone_id": z.zone_id, "name": z.name, "polygon": z.polygon.tolist()}

--- a/src/dino/spatial/spatial_pipeline.py
+++ b/src/dino/spatial/spatial_pipeline.py
@@ -62,6 +62,7 @@ class SpatialPipeline:
         # Localizer
         self._camera_intrinsics = None
         self._camera_pose = None
+        self._depth_estimator = None
 
         if spatial_config.camera_mode == "fixed":
             self._localizer = FixedCameraLocalizer()
@@ -73,7 +74,7 @@ class SpatialPipeline:
             self._depth_estimator = DepthEstimator(
                 model_id=spatial_config.depth_model,
             )
-            self._localizer = FixedCameraLocalizer()  # placeholder until run()
+            self._localizer = None  # finalized in run() once video dimensions are known
         else:
             raise ValueError(f"Unsupported camera_mode: {spatial_config.camera_mode!r}")
 
@@ -286,6 +287,11 @@ class SpatialPipeline:
         detections = self._tracker.update(detections)
 
         # Localize
+        if self._localizer is None:
+            raise RuntimeError(
+                "Localizer not initialized. In depth mode, run() must be called "
+                "to finalize the localizer with video dimensions."
+            )
         world_objects = self._localizer.localize(detections, frame, frame_idx)
 
         # Set timestamp on all objects

--- a/tests/test_camera_estimator.py
+++ b/tests/test_camera_estimator.py
@@ -1,0 +1,68 @@
+"""Tests for camera auto-estimation module."""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from dino.spatial.camera_estimator import estimate_camera
+from dino.spatial.models import CameraIntrinsics, CameraPose
+
+
+class TestEstimateCamera:
+    def test_returns_intrinsics_and_pose(self):
+        intrinsics, pose = estimate_camera(1920, 1080)
+        assert isinstance(intrinsics, CameraIntrinsics)
+        assert isinstance(pose, CameraPose)
+
+    def test_intrinsics_principal_point_centered(self):
+        intrinsics, _ = estimate_camera(1920, 1080)
+        assert intrinsics.cx == pytest.approx(960.0)
+        assert intrinsics.cy == pytest.approx(540.0)
+        assert intrinsics.width == 1920
+        assert intrinsics.height == 1080
+
+    def test_fov_affects_focal_length(self):
+        """Wider FOV -> shorter focal length."""
+        intrinsics_narrow, _ = estimate_camera(1920, 1080, fov_deg=50.0)
+        intrinsics_wide, _ = estimate_camera(1920, 1080, fov_deg=90.0)
+        assert intrinsics_narrow.fx > intrinsics_wide.fx
+
+    def test_focal_length_formula(self):
+        """Verify fx = width / (2 * tan(fov/2))."""
+        fov_deg = 70.0
+        width = 1920
+        expected_fx = width / (2 * math.tan(math.radians(fov_deg / 2)))
+        intrinsics, _ = estimate_camera(width, 1080, fov_deg=fov_deg)
+        assert intrinsics.fx == pytest.approx(expected_fx)
+        assert intrinsics.fy == pytest.approx(expected_fx)
+
+    def test_pose_translation_shape(self):
+        _, pose = estimate_camera(1920, 1080)
+        assert pose.translation.shape == (3,)
+
+    def test_pose_rotation_shape(self):
+        _, pose = estimate_camera(1920, 1080)
+        assert pose.rotation.shape == (3, 3)
+
+    def test_camera_above_ground(self):
+        """Camera Y translation should be positive (above ground)."""
+        _, pose = estimate_camera(1920, 1080)
+        # translation[1] is Y (height)
+        assert pose.translation[1] > 0
+
+    def test_rotation_is_valid(self):
+        """Rotation matrix should be orthogonal (R^T R ≈ I)."""
+        _, pose = estimate_camera(1920, 1080)
+        identity = pose.rotation.T @ pose.rotation
+        np.testing.assert_allclose(identity, np.eye(3), atol=1e-10)
+
+    def test_different_resolutions(self):
+        """Should work for various resolutions."""
+        for w, h in [(640, 480), (1280, 720), (3840, 2160)]:
+            intrinsics, pose = estimate_camera(w, h)
+            assert intrinsics.width == w
+            assert intrinsics.height == h
+            assert intrinsics.cx == pytest.approx(w / 2)
+            assert intrinsics.cy == pytest.approx(h / 2)

--- a/tests/test_depth_estimator.py
+++ b/tests/test_depth_estimator.py
@@ -29,11 +29,11 @@ class TestDepthEstimator:
         assert result.dtype == np.float32
 
     def test_estimate_normalized_range(self):
-        """Depth values should be in [0, 1]."""
+        """Depth values should be in [0, 1] via min-max normalization."""
         from dino.spatial.depth_estimator import DepthEstimator
 
         mock_pipe = MagicMock()
-        # Create depth with known range
+        # Create depth with known range — min-max normalization expected
         fake_depth = np.array([[0, 128], [255, 64]], dtype=np.uint8)
         mock_pipe.return_value = {"depth": fake_depth}
 
@@ -47,9 +47,47 @@ class TestDepthEstimator:
 
         assert result.min() >= 0.0
         assert result.max() <= 1.0
+        # Min-max: 0 -> 0.0, 255 -> 1.0, 128 -> 128/255, 64 -> 64/255
         assert result[0, 0] == pytest.approx(0.0)
         assert result[0, 1] == pytest.approx(128 / 255.0)
         assert result[1, 0] == pytest.approx(1.0)
+
+    def test_estimate_uniform_depth_returns_zeros(self):
+        """Uniform depth map (no variation) should return all zeros."""
+        from dino.spatial.depth_estimator import DepthEstimator
+
+        mock_pipe = MagicMock()
+        fake_depth = np.full((4, 4), 100, dtype=np.uint8)
+        mock_pipe.return_value = {"depth": fake_depth}
+
+        with patch(
+            "dino.spatial.depth_estimator.pipeline", return_value=mock_pipe
+        ):
+            estimator = DepthEstimator(device="cpu")
+
+        frame_bgr = np.zeros((4, 4, 3), dtype=np.uint8)
+        result = estimator.estimate(frame_bgr)
+        assert np.allclose(result, 0.0)
+
+    def test_estimate_handles_float_depth(self):
+        """Should normalize float depth maps (not just uint8)."""
+        from dino.spatial.depth_estimator import DepthEstimator
+
+        mock_pipe = MagicMock()
+        # Float depth with arbitrary range (not 0-255)
+        fake_depth = np.array([[0.5, 1.0], [2.0, 3.0]], dtype=np.float32)
+        mock_pipe.return_value = {"depth": fake_depth}
+
+        with patch(
+            "dino.spatial.depth_estimator.pipeline", return_value=mock_pipe
+        ):
+            estimator = DepthEstimator(device="cpu")
+
+        frame_bgr = np.zeros((2, 2, 3), dtype=np.uint8)
+        result = estimator.estimate(frame_bgr)
+
+        assert result.min() == pytest.approx(0.0)
+        assert result.max() == pytest.approx(1.0)
 
     def test_estimate_caches_nothing_by_default(self):
         """Each call invokes the pipeline (no built-in caching)."""

--- a/tests/test_depth_estimator.py
+++ b/tests/test_depth_estimator.py
@@ -1,0 +1,71 @@
+"""Tests for depth estimation module."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+class TestDepthEstimator:
+    def test_estimate_returns_depth_map(self):
+        """Mock pipeline returns HxW float32 depth map."""
+        from dino.spatial.depth_estimator import DepthEstimator
+
+        # Mock the pipeline
+        mock_pipe = MagicMock()
+        fake_depth = np.random.randint(0, 256, (240, 320), dtype=np.uint8)
+        mock_pipe.return_value = {"depth": fake_depth}
+
+        with patch(
+            "dino.spatial.depth_estimator.pipeline", return_value=mock_pipe
+        ):
+            estimator = DepthEstimator(device="cpu")
+
+        frame_bgr = np.zeros((240, 320, 3), dtype=np.uint8)
+        result = estimator.estimate(frame_bgr)
+
+        assert result.shape == (240, 320)
+        assert result.dtype == np.float32
+
+    def test_estimate_normalized_range(self):
+        """Depth values should be in [0, 1]."""
+        from dino.spatial.depth_estimator import DepthEstimator
+
+        mock_pipe = MagicMock()
+        # Create depth with known range
+        fake_depth = np.array([[0, 128], [255, 64]], dtype=np.uint8)
+        mock_pipe.return_value = {"depth": fake_depth}
+
+        with patch(
+            "dino.spatial.depth_estimator.pipeline", return_value=mock_pipe
+        ):
+            estimator = DepthEstimator(device="cpu")
+
+        frame_bgr = np.zeros((2, 2, 3), dtype=np.uint8)
+        result = estimator.estimate(frame_bgr)
+
+        assert result.min() >= 0.0
+        assert result.max() <= 1.0
+        assert result[0, 0] == pytest.approx(0.0)
+        assert result[0, 1] == pytest.approx(128 / 255.0)
+        assert result[1, 0] == pytest.approx(1.0)
+
+    def test_estimate_caches_nothing_by_default(self):
+        """Each call invokes the pipeline (no built-in caching)."""
+        from dino.spatial.depth_estimator import DepthEstimator
+
+        mock_pipe = MagicMock()
+        fake_depth = np.zeros((4, 4), dtype=np.uint8)
+        mock_pipe.return_value = {"depth": fake_depth}
+
+        with patch(
+            "dino.spatial.depth_estimator.pipeline", return_value=mock_pipe
+        ):
+            estimator = DepthEstimator(device="cpu")
+
+        frame = np.zeros((4, 4, 3), dtype=np.uint8)
+        estimator.estimate(frame)
+        estimator.estimate(frame)
+
+        assert mock_pipe.call_count == 2

--- a/tests/test_depth_localizer.py
+++ b/tests/test_depth_localizer.py
@@ -102,7 +102,7 @@ class TestDepthLocalizer:
         assert obj.frame_idx == 7
 
     def test_empty_detections(self):
-        """Empty detections should return empty list."""
+        """Empty detections should return empty list without running depth."""
         localizer, mock_estimator = self._make_localizer()
         dets = sv.Detections.empty()
         frame = np.zeros((240, 320, 3), dtype=np.uint8)
@@ -110,8 +110,8 @@ class TestDepthLocalizer:
         objects = localizer.localize(dets, frame, frame_idx=0)
 
         assert objects == []
-        # Depth estimation should still run (pipeline always estimates)
-        mock_estimator.estimate.assert_called_once()
+        # Depth estimation should NOT run for empty detections (optimization)
+        mock_estimator.estimate.assert_not_called()
 
     def test_no_tracker_id_uses_minus_one(self):
         """Detections without tracker_id should use -1."""

--- a/tests/test_depth_localizer.py
+++ b/tests/test_depth_localizer.py
@@ -1,0 +1,128 @@
+"""Tests for DepthLocalizer."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import supervision as sv
+
+from dino.spatial.camera_estimator import estimate_camera
+from dino.spatial.depth_localizer import DepthLocalizer
+from dino.spatial.models import WorldObject
+
+
+def _make_detections(n=1, bbox_center=(100, 100), size=40):
+    """Create detections centered at given pixel coords."""
+    half = size // 2
+    cx, cy = bbox_center
+    xyxy = np.array(
+        [[cx - half + i * 10, cy - half, cx + half + i * 10, cy + half] for i in range(n)],
+        dtype=np.float32,
+    )
+    return sv.Detections(
+        xyxy=xyxy,
+        confidence=np.array([0.9] * n, dtype=np.float32),
+        class_id=np.array([0] * n, dtype=int),
+        tracker_id=np.array(list(range(n)), dtype=int),
+        data={"class_name": np.array(["person"] * n)},
+    )
+
+
+class TestDepthLocalizer:
+    def _make_localizer(self, depth_value=0.5, frame_shape=(240, 320)):
+        """Create a DepthLocalizer with a mock depth estimator."""
+        intrinsics, pose = estimate_camera(frame_shape[1], frame_shape[0])
+        mock_estimator = MagicMock()
+        depth_map = np.full(frame_shape, depth_value, dtype=np.float32)
+        mock_estimator.estimate.return_value = depth_map
+        localizer = DepthLocalizer(intrinsics, pose, mock_estimator)
+        return localizer, mock_estimator
+
+    def test_localize_produces_3d_positions(self):
+        """Objects should have non-zero Z in world_position."""
+        localizer, _ = self._make_localizer(depth_value=0.5)
+        dets = _make_detections(n=2)
+        frame = np.zeros((240, 320, 3), dtype=np.uint8)
+
+        objects = localizer.localize(dets, frame, frame_idx=0)
+
+        assert len(objects) == 2
+        for obj in objects:
+            assert isinstance(obj, WorldObject)
+            assert obj.world_position.shape == (3,)
+            # With depth > 0, z should be non-zero (true 3D)
+            assert not np.allclose(obj.world_position, 0.0)
+
+    def test_depth_sampling_at_bbox_bottom(self):
+        """Depth should be sampled at bottom-center of bbox."""
+        localizer, mock_estimator = self._make_localizer()
+        # Create a non-uniform depth map to verify sampling location
+        depth_map = np.zeros((240, 320), dtype=np.float32)
+        # Put a specific value at the bottom-center of our bbox
+        # bbox will be [80, 80, 120, 120] -> bottom-center at (100, 120)
+        depth_map[120, 100] = 0.8
+        mock_estimator.estimate.return_value = depth_map
+
+        dets = _make_detections(n=1, bbox_center=(100, 100))
+        frame = np.zeros((240, 320, 3), dtype=np.uint8)
+
+        objects = localizer.localize(dets, frame, frame_idx=0)
+
+        # The depth used should be 0.8 (from bottom-center), not 0.0
+        # This verifies sampling at y2 (bottom), not center
+        assert len(objects) == 1
+        # World position should be non-zero since depth is 0.8
+        assert not np.allclose(objects[0].world_position, 0.0)
+
+    def test_zero_depth_clamps_to_epsilon(self):
+        """Zero depth should be clamped to avoid division errors."""
+        localizer, _ = self._make_localizer(depth_value=0.0)
+        dets = _make_detections(n=1)
+        frame = np.zeros((240, 320, 3), dtype=np.uint8)
+
+        # Should not raise
+        objects = localizer.localize(dets, frame, frame_idx=0)
+        assert len(objects) == 1
+        # Position should still be valid
+        assert np.all(np.isfinite(objects[0].world_position))
+
+    def test_metadata_preserved(self):
+        """Tracker ID, class name, confidence should be preserved."""
+        localizer, _ = self._make_localizer(depth_value=0.5)
+        dets = _make_detections(n=1)
+        frame = np.zeros((240, 320, 3), dtype=np.uint8)
+
+        objects = localizer.localize(dets, frame, frame_idx=7)
+
+        obj = objects[0]
+        assert obj.tracker_id == 0
+        assert obj.class_name == "person"
+        assert obj.confidence == pytest.approx(0.9)
+        assert obj.frame_idx == 7
+
+    def test_empty_detections(self):
+        """Empty detections should return empty list."""
+        localizer, mock_estimator = self._make_localizer()
+        dets = sv.Detections.empty()
+        frame = np.zeros((240, 320, 3), dtype=np.uint8)
+
+        objects = localizer.localize(dets, frame, frame_idx=0)
+
+        assert objects == []
+        # Depth estimation should still run (pipeline always estimates)
+        mock_estimator.estimate.assert_called_once()
+
+    def test_no_tracker_id_uses_minus_one(self):
+        """Detections without tracker_id should use -1."""
+        localizer, _ = self._make_localizer(depth_value=0.5)
+        dets = sv.Detections(
+            xyxy=np.array([[80, 80, 120, 120]], dtype=np.float32),
+            confidence=np.array([0.9], dtype=np.float32),
+            class_id=np.array([0], dtype=int),
+            data={"class_name": np.array(["person"])},
+        )
+        frame = np.zeros((240, 320, 3), dtype=np.uint8)
+
+        objects = localizer.localize(dets, frame, frame_idx=0)
+        assert objects[0].tracker_id == -1

--- a/tests/test_spatial_pipeline.py
+++ b/tests/test_spatial_pipeline.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -18,6 +19,12 @@ class TestSpatialConfig:
         assert config.max_age_seconds == 30.0
         assert config.zones_path is None
         assert config.rules is None
+        assert config.depth_model is None
+        assert config.camera_fov_deg == 70.0
+
+    def test_depth_mode_valid(self):
+        config = SpatialConfig(camera_mode="depth")
+        assert config.camera_mode == "depth"
 
     def test_invalid_camera_mode(self):
         with pytest.raises(ValueError, match="Unsupported camera_mode"):
@@ -649,3 +656,97 @@ class TestSpatialPipeline:
         assert data["metadata"]["stride"] == 1
         assert "zones" in data
         assert data["zones"] == []
+
+
+class TestSpatialPipelineDepthMode:
+    """Integration tests for camera_mode='depth'."""
+
+    @staticmethod
+    def _mock_transformers_pipeline():
+        """Mock the transformers pipeline to return fake depth maps."""
+        mock_pipe = MagicMock()
+        # Return a fake 240x320 uint8 depth image (will be normalized to float32)
+        fake_depth = np.full((240, 320), 128, dtype=np.uint8)
+        mock_pipe.return_value = {"depth": fake_depth}
+        return mock_pipe
+
+    def test_run_with_depth_mode(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        json_path = str(tmp_path / "results.json")
+        make_test_video(input_path, num_frames=3)
+
+        dets = make_detections(n=1)
+        detector = make_mock_detector(dets)
+        config = PipelineConfig(prompts=["person"])
+
+        mock_pipe = self._mock_transformers_pipeline()
+        with patch(
+            "dino.spatial.depth_estimator.pipeline",
+            return_value=mock_pipe,
+        ):
+            spatial_config = SpatialConfig(camera_mode="depth")
+            pipeline = SpatialPipeline(detector, config, spatial_config)
+            results = pipeline.run(input_path, output_path, json_output=json_path)
+
+        assert len(results.frame_results) == 3
+        # Objects should have 3D positions (z != 0)
+        obj = results.frame_results[0]["objects"][0]
+        wp = obj["world_position"]
+        assert len(wp) == 3
+        assert wp[2] != 0.0  # non-flat
+
+    def test_json_export_has_camera_metadata(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        json_path = str(tmp_path / "results.json")
+        make_test_video(input_path, num_frames=2)
+
+        detector = make_mock_detector()
+        config = PipelineConfig(prompts=["person"])
+
+        mock_pipe = self._mock_transformers_pipeline()
+        with patch(
+            "dino.spatial.depth_estimator.pipeline",
+            return_value=mock_pipe,
+        ):
+            spatial_config = SpatialConfig(camera_mode="depth", camera_fov_deg=60.0)
+            pipeline = SpatialPipeline(detector, config, spatial_config)
+            pipeline.run(input_path, output_path, json_output=json_path)
+
+        with open(json_path) as f:
+            data = json.load(f)
+
+        cam = data["metadata"]["camera"]
+        assert cam is not None
+        assert isinstance(cam["position"], list)
+        assert len(cam["position"]) == 3
+        assert isinstance(cam["rotation"], list)
+        assert len(cam["rotation"]) == 3
+        assert cam["fov_deg"] == 60.0
+        assert "intrinsics" in cam
+        assert cam["intrinsics"]["width"] == 320
+        assert cam["intrinsics"]["height"] == 240
+
+    def test_fixed_mode_has_no_camera_metadata(self, tmp_path):
+        from dino.spatial.spatial_pipeline import SpatialPipeline
+
+        input_path = str(tmp_path / "input.mp4")
+        output_path = str(tmp_path / "output.mp4")
+        json_path = str(tmp_path / "results.json")
+        make_test_video(input_path, num_frames=2)
+
+        detector = make_mock_detector()
+        config = PipelineConfig(prompts=["person"])
+        spatial_config = SpatialConfig(camera_mode="fixed")
+        pipeline = SpatialPipeline(detector, config, spatial_config)
+        pipeline.run(input_path, output_path, json_output=json_path)
+
+        with open(json_path) as f:
+            data = json.load(f)
+
+        assert data["metadata"]["camera"] is None

--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -17,12 +17,17 @@ let stopRenderLoop = null;
 let abortController = null;
 let currentRenderer = null;
 let currentLabelRenderer = null;
+let currentCameraRenderer = null;
 
 function initViewer(data) {
   // Cleanup previous state
   if (timeline) timeline.destroy();
   if (stopRenderLoop) stopRenderLoop();
   if (abortController) abortController.abort();
+  if (currentCameraRenderer) {
+    currentCameraRenderer.dispose();
+    currentCameraRenderer = null;
+  }
   if (currentRenderer) {
     currentRenderer.dispose();
     currentRenderer.domElement.remove();
@@ -56,8 +61,8 @@ function initViewer(data) {
 
     // Camera frustum visualization (only in depth mode)
     if (hasCamera) {
-      const cameraRenderer = new CameraRenderer(scene);
-      cameraRenderer.renderCamera(metadata.camera);
+      currentCameraRenderer = new CameraRenderer(scene);
+      currentCameraRenderer.renderCamera(metadata.camera);
     }
 
     // UI elements

--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -6,6 +6,7 @@ import { createScene, startRenderLoop } from './scene.js';
 import { createFloorPlan } from './floor-plan.js';
 import { ZoneRenderer } from './zone-renderer.js';
 import { ObjectRenderer } from './object-renderer.js';
+import { CameraRenderer } from './camera-renderer.js';
 import { Timeline } from './timeline.js';
 
 const PLAY_SYMBOL = '\u25B6';
@@ -36,10 +37,11 @@ function initViewer(data) {
     const metadata = getMetadata(data);
     const zones = getZones(data);
     const frameIndex = buildFrameIndex(data);
+    const hasCamera = !!(metadata.camera);
 
     const container = document.getElementById('scene-container');
     const { scene, camera, renderer, controls, labelRenderer } = createScene(
-      container, metadata.width, metadata.height, signal
+      container, metadata.width, metadata.height, signal, { hasCamera }
     );
 
     currentRenderer = renderer;
@@ -50,7 +52,13 @@ function initViewer(data) {
     const zoneRenderer = new ZoneRenderer(scene, metadata.width, metadata.height);
     zoneRenderer.renderZones(zones);
 
-    const objectRenderer = new ObjectRenderer(scene, metadata.width, metadata.height);
+    const objectRenderer = new ObjectRenderer(scene, metadata.width, metadata.height, hasCamera);
+
+    // Camera frustum visualization (only in depth mode)
+    if (hasCamera) {
+      const cameraRenderer = new CameraRenderer(scene);
+      cameraRenderer.renderCamera(metadata.camera);
+    }
 
     // UI elements
     const scrubber = document.getElementById('scrubber');

--- a/viewer/js/camera-renderer.js
+++ b/viewer/js/camera-renderer.js
@@ -1,0 +1,92 @@
+/**
+ * Camera frustum visualization for the DINO 3D Spatial Viewer.
+ */
+import * as THREE from 'three';
+
+export class CameraRenderer {
+  constructor(scene) {
+    this.scene = scene;
+    this.frustumGroup = null;
+  }
+
+  renderCamera(cameraData) {
+    if (!cameraData) return;
+
+    // Clean up previous frustum
+    if (this.frustumGroup) {
+      this.scene.remove(this.frustumGroup);
+      this.frustumGroup.traverse(child => {
+        if (child.geometry) child.geometry.dispose();
+        if (child.material) child.material.dispose();
+      });
+    }
+
+    this.frustumGroup = new THREE.Group();
+
+    const { position, rotation, fov_deg, intrinsics } = cameraData;
+
+    // Camera position in Three.js coordinates (Y-up)
+    const camPos = new THREE.Vector3(position[0], position[1], -position[2]);
+
+    // Build rotation matrix from the 3x3 array
+    const rotMatrix = new THREE.Matrix4();
+    rotMatrix.set(
+      rotation[0][0], rotation[0][1], -rotation[0][2], 0,
+      rotation[1][0], rotation[1][1], -rotation[1][2], 0,
+      -rotation[2][0], -rotation[2][1], rotation[2][2], 0,
+      0, 0, 0, 1,
+    );
+
+    // Create a helper camera matching the frustum parameters
+    const aspect = intrinsics.width / intrinsics.height;
+    const helperCam = new THREE.PerspectiveCamera(fov_deg / aspect, aspect, 10, camPos.length() * 1.5);
+    helperCam.position.copy(camPos);
+    helperCam.lookAt(0, 0, 0);
+    helperCam.updateProjectionMatrix();
+
+    // Camera helper (wireframe frustum)
+    const helper = new THREE.CameraHelper(helperCam);
+    this.frustumGroup.add(helper);
+
+    // Semi-transparent cone showing field of view volume
+    const coneHeight = camPos.length() * 0.8;
+    const coneRadius = coneHeight * Math.tan(THREE.MathUtils.degToRad(fov_deg / 2));
+    const coneGeo = new THREE.ConeGeometry(coneRadius, coneHeight, 32, 1, true);
+    const coneMat = new THREE.MeshBasicMaterial({
+      color: 0x38bdf8,
+      transparent: true,
+      opacity: 0.08,
+      side: THREE.DoubleSide,
+      depthWrite: false,
+    });
+    const cone = new THREE.Mesh(coneGeo, coneMat);
+
+    // Position cone: tip at camera, opening towards ground
+    const midpoint = camPos.clone().multiplyScalar(0.5);
+    cone.position.copy(midpoint);
+    cone.lookAt(0, 0, 0);
+    cone.rotateX(Math.PI / 2);
+
+    this.frustumGroup.add(cone);
+
+    // Camera position marker (small sphere)
+    const sphereGeo = new THREE.SphereGeometry(6, 12, 12);
+    const sphereMat = new THREE.MeshStandardMaterial({ color: 0xfbbf24 });
+    const sphere = new THREE.Mesh(sphereGeo, sphereMat);
+    sphere.position.copy(camPos);
+    this.frustumGroup.add(sphere);
+
+    this.scene.add(this.frustumGroup);
+  }
+
+  dispose() {
+    if (this.frustumGroup) {
+      this.scene.remove(this.frustumGroup);
+      this.frustumGroup.traverse(child => {
+        if (child.geometry) child.geometry.dispose();
+        if (child.material) child.material.dispose();
+      });
+      this.frustumGroup = null;
+    }
+  }
+}

--- a/viewer/js/camera-renderer.js
+++ b/viewer/js/camera-renderer.js
@@ -9,37 +9,34 @@ export class CameraRenderer {
     this.frustumGroup = null;
   }
 
+  _cleanupFrustum() {
+    if (!this.frustumGroup) return;
+    this.scene.remove(this.frustumGroup);
+    this.frustumGroup.traverse(child => {
+      if (child.geometry) child.geometry.dispose();
+      if (child.material) child.material.dispose();
+    });
+    this.frustumGroup = null;
+  }
+
   renderCamera(cameraData) {
     if (!cameraData) return;
 
-    // Clean up previous frustum
-    if (this.frustumGroup) {
-      this.scene.remove(this.frustumGroup);
-      this.frustumGroup.traverse(child => {
-        if (child.geometry) child.geometry.dispose();
-        if (child.material) child.material.dispose();
-      });
-    }
-
+    this._cleanupFrustum();
     this.frustumGroup = new THREE.Group();
 
-    const { position, rotation, fov_deg, intrinsics } = cameraData;
+    const { position, fov_deg, intrinsics } = cameraData;
 
     // Camera position in Three.js coordinates (Y-up)
     const camPos = new THREE.Vector3(position[0], position[1], -position[2]);
 
-    // Build rotation matrix from the 3x3 array
-    const rotMatrix = new THREE.Matrix4();
-    rotMatrix.set(
-      rotation[0][0], rotation[0][1], -rotation[0][2], 0,
-      rotation[1][0], rotation[1][1], -rotation[1][2], 0,
-      -rotation[2][0], -rotation[2][1], rotation[2][2], 0,
-      0, 0, 0, 1,
-    );
+    // Convert horizontal FOV to vertical FOV for Three.js PerspectiveCamera
+    const aspect = intrinsics.width / intrinsics.height;
+    const vFovRad = 2 * Math.atan(Math.tan(THREE.MathUtils.degToRad(fov_deg / 2)) / aspect);
+    const vFovDeg = THREE.MathUtils.radToDeg(vFovRad);
 
     // Create a helper camera matching the frustum parameters
-    const aspect = intrinsics.width / intrinsics.height;
-    const helperCam = new THREE.PerspectiveCamera(fov_deg / aspect, aspect, 10, camPos.length() * 1.5);
+    const helperCam = new THREE.PerspectiveCamera(vFovDeg, aspect, 10, camPos.length() * 1.5);
     helperCam.position.copy(camPos);
     helperCam.lookAt(0, 0, 0);
     helperCam.updateProjectionMatrix();
@@ -80,13 +77,6 @@ export class CameraRenderer {
   }
 
   dispose() {
-    if (this.frustumGroup) {
-      this.scene.remove(this.frustumGroup);
-      this.frustumGroup.traverse(child => {
-        if (child.geometry) child.geometry.dispose();
-        if (child.material) child.material.dispose();
-      });
-      this.frustumGroup = null;
-    }
+    this._cleanupFrustum();
   }
 }

--- a/viewer/js/camera-renderer.js
+++ b/viewer/js/camera-renderer.js
@@ -26,6 +26,10 @@ export class CameraRenderer {
     this.frustumGroup = new THREE.Group();
 
     const { position, fov_deg, intrinsics } = cameraData;
+    if (!position || !intrinsics || !fov_deg) {
+      console.warn('CameraRenderer: cameraData missing required fields, skipping frustum.');
+      return;
+    }
 
     // Camera position in Three.js coordinates (Y-up)
     const camPos = new THREE.Vector3(position[0], position[1], -position[2]);
@@ -47,7 +51,7 @@ export class CameraRenderer {
 
     // Semi-transparent cone showing field of view volume
     const coneHeight = camPos.length() * 0.8;
-    const coneRadius = coneHeight * Math.tan(THREE.MathUtils.degToRad(fov_deg / 2));
+    const coneRadius = coneHeight * Math.tan(vFovRad / 2);
     const coneGeo = new THREE.ConeGeometry(coneRadius, coneHeight, 32, 1, true);
     const coneMat = new THREE.MeshBasicMaterial({
       color: 0x38bdf8,

--- a/viewer/js/object-renderer.js
+++ b/viewer/js/object-renderer.js
@@ -66,10 +66,10 @@ export class ObjectRenderer {
 
         // Update position from world_position
         const wp = obj.world_position;
-        if (this.hasCamera && wp.length >= 3 && wp[2] !== 0) {
+        if (this.hasCamera) {
           // Real 3D mode: world positions from depth estimation
           // Map to Three.js Y-up: [x, z, -y]
-          entry.group.position.set(wp[0], wp[2], -wp[1]);
+          entry.group.position.set(wp[0], wp[2] || 0, -wp[1]);
         } else {
           // Legacy flat mode: pixel-space positions
           const pos = pixelToWorld(wp[0], wp[1], this.width, this.height);

--- a/viewer/js/object-renderer.js
+++ b/viewer/js/object-renderer.js
@@ -14,10 +14,11 @@ const MARKER_RADIUS = 4;
 const MARKER_HEIGHT = 12;
 
 export class ObjectRenderer {
-  constructor(scene, width, height) {
+  constructor(scene, width, height, hasCamera = false) {
     this.scene = scene;
     this.width = width;
     this.height = height;
+    this.hasCamera = hasCamera;
     this.pool = new Map(); // persistent_id -> { mesh, label, group }
   }
 
@@ -65,8 +66,15 @@ export class ObjectRenderer {
 
         // Update position from world_position
         const wp = obj.world_position;
-        const pos = pixelToWorld(wp[0], wp[1], this.width, this.height);
-        entry.group.position.set(pos.x, 0, pos.z);
+        if (this.hasCamera && wp.length >= 3 && wp[2] !== 0) {
+          // Real 3D mode: world positions from depth estimation
+          // Map to Three.js Y-up: [x, z, -y]
+          entry.group.position.set(wp[0], wp[2], -wp[1]);
+        } else {
+          // Legacy flat mode: pixel-space positions
+          const pos = pixelToWorld(wp[0], wp[1], this.width, this.height);
+          entry.group.position.set(pos.x, 0, pos.z);
+        }
         entry.group.visible = true;
 
         // Update label

--- a/viewer/js/object-renderer.js
+++ b/viewer/js/object-renderer.js
@@ -69,7 +69,8 @@ export class ObjectRenderer {
         if (this.hasCamera) {
           // Real 3D mode: world positions from depth estimation
           // Map to Three.js Y-up: [x, z, -y]
-          entry.group.position.set(wp[0], wp[2] || 0, -wp[1]);
+          const z = wp[2] ?? 0;
+          entry.group.position.set(wp[0], z, -wp[1]);
         } else {
           // Legacy flat mode: pixel-space positions
           const pos = pixelToWorld(wp[0], wp[1], this.width, this.height);

--- a/viewer/js/scene.js
+++ b/viewer/js/scene.js
@@ -5,20 +5,29 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { CSS2DRenderer } from 'three/addons/renderers/CSS2DRenderer.js';
 
-export function createScene(container, width, height, signal) {
+export function createScene(container, width, height, signal, { hasCamera = false } = {}) {
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0x0f172a);
 
-  // Orthographic camera — top-down view
   const aspect = container.clientWidth / container.clientHeight;
-  const frustumSize = Math.max(width, height) * 0.6;
-  const camera = new THREE.OrthographicCamera(
-    -frustumSize * aspect, frustumSize * aspect,
-    frustumSize, -frustumSize,
-    0.1, 2000
-  );
-  camera.position.set(0, 500, 0);
-  camera.lookAt(0, 0, 0);
+  let camera;
+
+  if (hasCamera) {
+    // Perspective camera for 3D depth mode — better depth perception
+    camera = new THREE.PerspectiveCamera(60, aspect, 1, 5000);
+    camera.position.set(0, Math.max(width, height) * 0.8, Math.max(width, height) * 0.6);
+    camera.lookAt(0, 0, 0);
+  } else {
+    // Orthographic camera — top-down view for flat mode
+    const frustumSize = Math.max(width, height) * 0.6;
+    camera = new THREE.OrthographicCamera(
+      -frustumSize * aspect, frustumSize * aspect,
+      frustumSize, -frustumSize,
+      0.1, 2000
+    );
+    camera.position.set(0, 500, 0);
+    camera.lookAt(0, 0, 0);
+  }
 
   // WebGL renderer
   const renderer = new THREE.WebGLRenderer({ antialias: true });
@@ -53,10 +62,15 @@ export function createScene(container, width, height, signal) {
     const w = container.clientWidth;
     const h = container.clientHeight;
     const a = w / h;
-    camera.left = -frustumSize * a;
-    camera.right = frustumSize * a;
-    camera.top = frustumSize;
-    camera.bottom = -frustumSize;
+    if (camera.isPerspectiveCamera) {
+      camera.aspect = a;
+    } else {
+      const frustumSize = Math.max(width, height) * 0.6;
+      camera.left = -frustumSize * a;
+      camera.right = frustumSize * a;
+      camera.top = frustumSize;
+      camera.bottom = -frustumSize;
+    }
     camera.updateProjectionMatrix();
     renderer.setSize(w, h);
     labelRenderer.setSize(w, h);


### PR DESCRIPTION
## Summary
- Add Depth Anything v2 monocular depth estimation for true 3D object positioning
- Add camera frustum visualization (wireframe + FOV cone) in the 3D viewer
- Heuristic camera auto-estimation for typical CCTV/overhead cameras
- New `camera_mode="depth"` config option with backward-compatible `"fixed"` default

## New Files
| File | What |
|------|------|
| `src/dino/spatial/depth_estimator.py` | Depth Anything v2 wrapper |
| `src/dino/spatial/camera_estimator.py` | Heuristic camera auto-estimation |
| `src/dino/spatial/depth_localizer.py` | BaseLocalizer subclass with depth + projection |
| `viewer/js/camera-renderer.js` | Camera frustum visualization |
| `tests/test_depth_estimator.py` | 3 unit tests |
| `tests/test_camera_estimator.py` | 9 unit tests |
| `tests/test_depth_localizer.py` | 6 unit tests |

## Modified Files
| File | What |
|------|------|
| `src/dino/config.py` | Add `"depth"` mode + `depth_model`, `camera_fov_deg` fields |
| `src/dino/spatial/spatial_pipeline.py` | Wire depth localizer + camera metadata in JSON |
| `scripts/demo_spatial.py` | Add `--camera-mode depth`, `--camera-fov`, `--depth-model` CLI args |
| `viewer/js/object-renderer.js` | Support real 3D positions |
| `viewer/js/scene.js` | Perspective camera when camera model present |
| `viewer/js/app.js` | Wire camera renderer |
| `tests/test_spatial_pipeline.py` | 3 integration tests for depth mode |

## Reuses existing infrastructure
- `CameraIntrinsics`, `CameraPose` — `src/dino/spatial/models.py`
- `backproject_to_world()` — `src/dino/spatial/projection.py`
- `BaseLocalizer` — `src/dino/spatial/base_localizer.py`
- `transformers` already in dependencies

## Test plan
- [x] 18 new unit tests pass (depth estimator, camera estimator, depth localizer)
- [x] 3 new integration tests pass (depth mode pipeline, camera metadata, backward compat)
- [x] Full suite: 224 tests passing, zero regressions
- [ ] Manual: run with `--camera-mode depth`, verify 3D positions in viewer
- [ ] Manual: verify camera frustum visible in 3D scene
- [ ] Manual: verify legacy `--camera-mode fixed` still works

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)