### PR TITLE
feat: multi-view annotation + top-down + 3D depth panels

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -22,9 +22,26 @@
         Load JSON
         <input type="file" id="file-input" accept=".json" />
       </label>
+      <label class="file-input-label file-input-video">
+        Load Video
+        <input type="file" id="video-input" accept="video/*" />
+      </label>
       <span id="status">No data loaded</span>
     </header>
-    <main id="scene-container"></main>
+    <main id="viewport-strip">
+      <div class="panel" id="panel-annotation">
+        <div class="panel-label">Annotation</div>
+        <div class="panel-content" id="annotation-content"></div>
+      </div>
+      <div class="panel" id="panel-topdown">
+        <div class="panel-label">Top-down</div>
+        <div class="panel-content" id="topdown-content"></div>
+      </div>
+      <div class="panel" id="panel-depth">
+        <div class="panel-label">3D Depth</div>
+        <div class="panel-content" id="depth-content"></div>
+      </div>
+    </main>
     <footer id="timeline-bar">
       <button id="step-back" title="Step back">&lt;&lt;</button>
       <button id="play-pause" title="Play/Pause">&#9654;</button>

--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -164,7 +164,7 @@ function initViewer(data) {
 
     // --- Auto-load video ---
     probeVideoUrl('spatial_annotated.mp4').then(url => {
-      if (url && !signal.aborted) videoPanel.loadVideo(url);
+      if (url && !signal.aborted && videoPanel) videoPanel.loadVideo(url);
     }).catch(() => {});
 
   } catch (err) {

--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -21,10 +21,6 @@ let videoPanel = null;
 // Disposable per-init state
 let disposables = [];
 
-function clearContainer(el) {
-  while (el.firstChild) el.removeChild(el.firstChild);
-}
-
 function cleanup() {
   if (timeline) { timeline.destroy(); timeline = null; }
   if (stopLoop) { stopLoop(); stopLoop = null; }
@@ -36,10 +32,9 @@ function cleanup() {
   }
   disposables = [];
 
-  // Clear panel contents
   for (const id of ['annotation-content', 'topdown-content', 'depth-content']) {
     const el = document.getElementById(id);
-    if (el) clearContainer(el);
+    if (el) el.replaceChildren();
   }
 }
 
@@ -52,7 +47,7 @@ function initViewer(data) {
     const metadata = getMetadata(data);
     const zones = getZones(data);
     const frameIndex = buildFrameIndex(data);
-    const hasCamera = !!(metadata.camera);
+    const hasCamera = Boolean(metadata.camera);
 
     const strip = document.getElementById('viewport-strip');
     strip.classList.toggle('two-col', !hasCamera);
@@ -61,37 +56,30 @@ function initViewer(data) {
     const annotationContainer = document.getElementById('annotation-content');
     videoPanel = new VideoPanel(annotationContainer, metadata);
 
-    // --- Top-down panel (orthographic) ---
-    const topDownContainer = document.getElementById('topdown-content');
-    const topDownBundle = createSceneBundle(
-      topDownContainer, metadata.width, metadata.height, signal, { mode: 'orthographic' }
-    );
-    disposables.push(topDownBundle.renderer, topDownBundle.labelRenderer);
+    // Shared setup: scene bundle + floor plan + zones + objects
+    function buildPanel(containerId, mode, useDepth) {
+      const container = document.getElementById(containerId);
+      const bundle = createSceneBundle(
+        container, metadata.width, metadata.height, signal, { mode }
+      );
+      disposables.push(bundle.renderer, bundle.labelRenderer);
+      createFloorPlan(bundle.scene, metadata.width, metadata.height);
+      const zoneRenderer = new ZoneRenderer(bundle.scene, metadata.width, metadata.height);
+      zoneRenderer.renderZones(zones);
+      const objectRenderer = new ObjectRenderer(bundle.scene, metadata.width, metadata.height, useDepth);
+      return { bundle, zoneRenderer, objectRenderer };
+    }
 
-    createFloorPlan(topDownBundle.scene, metadata.width, metadata.height);
-    const topDownZones = new ZoneRenderer(topDownBundle.scene, metadata.width, metadata.height);
-    topDownZones.renderZones(zones);
-    const topDownObjects = new ObjectRenderer(topDownBundle.scene, metadata.width, metadata.height, false);
+    // --- Top-down panel (orthographic) ---
+    const topDown = buildPanel('topdown-content', 'orthographic', false);
 
     // --- 3D Depth panel (perspective, only if camera data) ---
-    let depthBundle = null;
-    let depthZones = null;
-    let depthObjects = null;
+    let depth = null;
     let cameraRenderer = null;
 
     if (hasCamera) {
-      const depthContainer = document.getElementById('depth-content');
-      depthBundle = createSceneBundle(
-        depthContainer, metadata.width, metadata.height, signal, { mode: 'perspective' }
-      );
-      disposables.push(depthBundle.renderer, depthBundle.labelRenderer);
-
-      createFloorPlan(depthBundle.scene, metadata.width, metadata.height);
-      depthZones = new ZoneRenderer(depthBundle.scene, metadata.width, metadata.height);
-      depthZones.renderZones(zones);
-      depthObjects = new ObjectRenderer(depthBundle.scene, metadata.width, metadata.height, true);
-
-      cameraRenderer = new CameraRenderer(depthBundle.scene);
+      depth = buildPanel('depth-content', 'perspective', true);
+      cameraRenderer = new CameraRenderer(depth.bundle.scene);
       cameraRenderer.renderCamera(metadata.camera);
       disposables.push(cameraRenderer);
     }
@@ -118,12 +106,14 @@ function initViewer(data) {
       videoPanel.seekToFrame(frameIdx, frameData);
 
       // Top-down panel
-      topDownObjects.updateObjects(frameData ? frameData.objects : null);
-      topDownZones.updateFromFrame(frameData);
+      topDown.objectRenderer.updateObjects(frameData ? frameData.objects : null);
+      topDown.zoneRenderer.updateFromFrame(frameData);
 
       // 3D Depth panel
-      if (depthObjects) depthObjects.updateObjects(frameData ? frameData.objects : null);
-      if (depthZones) depthZones.updateFromFrame(frameData);
+      if (depth) {
+        depth.objectRenderer.updateObjects(frameData ? frameData.objects : null);
+        depth.zoneRenderer.updateFromFrame(frameData);
+      }
 
       // Timeline UI
       timeDisplay.textContent = timeline.getTimeString();
@@ -169,13 +159,13 @@ function initViewer(data) {
     timeline.seekToKeyIndex(0);
 
     // --- Render loop — single RAF for all bundles ---
-    const bundles = [topDownBundle, depthBundle].filter(Boolean);
+    const bundles = [topDown.bundle, depth?.bundle].filter(Boolean);
     stopLoop = startRenderLoop(bundles);
 
     // --- Auto-load video ---
     probeVideoUrl('spatial_annotated.mp4').then(url => {
-      if (url) videoPanel.loadVideo(url);
-    });
+      if (url && !signal.aborted) videoPanel.loadVideo(url);
+    }).catch(() => {});
 
   } catch (err) {
     console.error('Failed to initialize viewer:', err);
@@ -200,7 +190,11 @@ document.addEventListener('DOMContentLoaded', () => {
   // Video file input
   document.getElementById('video-input').addEventListener('change', (e) => {
     const file = e.target.files[0];
-    if (!file || !videoPanel) return;
+    if (!file) return;
+    if (!videoPanel) {
+      document.getElementById('status').textContent = 'Load a JSON file first before adding video.';
+      return;
+    }
     videoPanel.loadVideo(file);
   });
 

--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -1,40 +1,50 @@
 /**
  * Main entry point for the DINO 3D Spatial Viewer.
  */
-import { loadData, buildFrameIndex, getMetadata, getZones } from './data-loader.js';
-import { createScene, startRenderLoop } from './scene.js';
+import { loadData, buildFrameIndex, getMetadata, getZones, probeVideoUrl } from './data-loader.js';
+import { createSceneBundle, startRenderLoop } from './scene.js';
 import { createFloorPlan } from './floor-plan.js';
 import { ZoneRenderer } from './zone-renderer.js';
 import { ObjectRenderer } from './object-renderer.js';
 import { CameraRenderer } from './camera-renderer.js';
 import { Timeline } from './timeline.js';
+import { VideoPanel } from './video-panel.js';
 
 const PLAY_SYMBOL = '\u25B6';
 const PAUSE_SYMBOL = '\u23F8';
 
 let timeline = null;
-let stopRenderLoop = null;
+let stopLoop = null;
 let abortController = null;
-let currentRenderer = null;
-let currentLabelRenderer = null;
-let currentCameraRenderer = null;
+let videoPanel = null;
+
+// Disposable per-init state
+let disposables = [];
+
+function clearContainer(el) {
+  while (el.firstChild) el.removeChild(el.firstChild);
+}
+
+function cleanup() {
+  if (timeline) { timeline.destroy(); timeline = null; }
+  if (stopLoop) { stopLoop(); stopLoop = null; }
+  if (abortController) abortController.abort();
+  if (videoPanel) { videoPanel.dispose(); videoPanel = null; }
+  for (const d of disposables) {
+    if (typeof d.dispose === 'function') d.dispose();
+    if (d.domElement) d.domElement.remove();
+  }
+  disposables = [];
+
+  // Clear panel contents
+  for (const id of ['annotation-content', 'topdown-content', 'depth-content']) {
+    const el = document.getElementById(id);
+    if (el) clearContainer(el);
+  }
+}
 
 function initViewer(data) {
-  // Cleanup previous state
-  if (timeline) timeline.destroy();
-  if (stopRenderLoop) stopRenderLoop();
-  if (abortController) abortController.abort();
-  if (currentCameraRenderer) {
-    currentCameraRenderer.dispose();
-    currentCameraRenderer = null;
-  }
-  if (currentRenderer) {
-    currentRenderer.dispose();
-    currentRenderer.domElement.remove();
-  }
-  if (currentLabelRenderer) {
-    currentLabelRenderer.domElement.remove();
-  }
+  cleanup();
   abortController = new AbortController();
   const signal = abortController.signal;
 
@@ -44,28 +54,49 @@ function initViewer(data) {
     const frameIndex = buildFrameIndex(data);
     const hasCamera = !!(metadata.camera);
 
-    const container = document.getElementById('scene-container');
-    const { scene, camera, renderer, controls, labelRenderer } = createScene(
-      container, metadata.width, metadata.height, signal, { hasCamera }
+    const strip = document.getElementById('viewport-strip');
+    strip.classList.toggle('two-col', !hasCamera);
+
+    // --- Annotation (video) panel ---
+    const annotationContainer = document.getElementById('annotation-content');
+    videoPanel = new VideoPanel(annotationContainer, metadata);
+
+    // --- Top-down panel (orthographic) ---
+    const topDownContainer = document.getElementById('topdown-content');
+    const topDownBundle = createSceneBundle(
+      topDownContainer, metadata.width, metadata.height, signal, { mode: 'orthographic' }
     );
+    disposables.push(topDownBundle.renderer, topDownBundle.labelRenderer);
 
-    currentRenderer = renderer;
-    currentLabelRenderer = labelRenderer;
+    createFloorPlan(topDownBundle.scene, metadata.width, metadata.height);
+    const topDownZones = new ZoneRenderer(topDownBundle.scene, metadata.width, metadata.height);
+    topDownZones.renderZones(zones);
+    const topDownObjects = new ObjectRenderer(topDownBundle.scene, metadata.width, metadata.height, false);
 
-    createFloorPlan(scene, metadata.width, metadata.height);
+    // --- 3D Depth panel (perspective, only if camera data) ---
+    let depthBundle = null;
+    let depthZones = null;
+    let depthObjects = null;
+    let cameraRenderer = null;
 
-    const zoneRenderer = new ZoneRenderer(scene, metadata.width, metadata.height);
-    zoneRenderer.renderZones(zones);
-
-    const objectRenderer = new ObjectRenderer(scene, metadata.width, metadata.height, hasCamera);
-
-    // Camera frustum visualization (only in depth mode)
     if (hasCamera) {
-      currentCameraRenderer = new CameraRenderer(scene);
-      currentCameraRenderer.renderCamera(metadata.camera);
+      const depthContainer = document.getElementById('depth-content');
+      depthBundle = createSceneBundle(
+        depthContainer, metadata.width, metadata.height, signal, { mode: 'perspective' }
+      );
+      disposables.push(depthBundle.renderer, depthBundle.labelRenderer);
+
+      createFloorPlan(depthBundle.scene, metadata.width, metadata.height);
+      depthZones = new ZoneRenderer(depthBundle.scene, metadata.width, metadata.height);
+      depthZones.renderZones(zones);
+      depthObjects = new ObjectRenderer(depthBundle.scene, metadata.width, metadata.height, true);
+
+      cameraRenderer = new CameraRenderer(depthBundle.scene);
+      cameraRenderer.renderCamera(metadata.camera);
+      disposables.push(cameraRenderer);
     }
 
-    // UI elements
+    // --- UI elements ---
     const scrubber = document.getElementById('scrubber');
     const timeDisplay = document.getElementById('time-display');
     const playPauseBtn = document.getElementById('play-pause');
@@ -81,14 +112,23 @@ function initViewer(data) {
       playPauseBtn.textContent = timeline.isPlaying ? PAUSE_SYMBOL : PLAY_SYMBOL;
     }
 
-    // Frame change handler
+    // --- Frame change handler — fan out to all panels ---
     function onFrameChange(frameIdx, frameData) {
-      objectRenderer.updateObjects(frameData ? frameData.objects : null);
-      zoneRenderer.updateFromFrame(frameData);
+      // Video panel
+      videoPanel.seekToFrame(frameIdx, frameData);
+
+      // Top-down panel
+      topDownObjects.updateObjects(frameData ? frameData.objects : null);
+      topDownZones.updateFromFrame(frameData);
+
+      // 3D Depth panel
+      if (depthObjects) depthObjects.updateObjects(frameData ? frameData.objects : null);
+      if (depthZones) depthZones.updateFromFrame(frameData);
+
+      // Timeline UI
       timeDisplay.textContent = timeline.getTimeString();
       scrubber.value = timeline.currentKeyIndex;
 
-      // Count events up to current frame
       let eventsToFrame = 0;
       if (data.events) {
         for (const e of data.events) {
@@ -98,17 +138,14 @@ function initViewer(data) {
       eventCount.textContent = `Events: ${eventsToFrame} / ${totalEvents}`;
     }
 
-    // Create timeline
+    // --- Timeline ---
     timeline = new Timeline(metadata, frameIndex, onFrameChange);
-
-    // Set up scrubber
     scrubber.max = timeline.frameKeys.length - 1;
     scrubber.value = 0;
     scrubber.addEventListener('input', () => {
       timeline.seekToKeyIndex(parseInt(scrubber.value, 10));
     }, { signal });
 
-    // Controls
     playPauseBtn.addEventListener('click', () => {
       timeline.togglePlayPause();
       updatePlayPauseButton();
@@ -119,7 +156,6 @@ function initViewer(data) {
       timeline.setSpeed(parseFloat(speedSelect.value));
     }, { signal });
 
-    // Keyboard shortcuts
     document.addEventListener('keydown', (e) => {
       if (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT') return;
       if (e.code === 'Space') { e.preventDefault(); timeline.togglePlayPause(); updatePlayPauseButton(); }
@@ -132,7 +168,15 @@ function initViewer(data) {
     // Trigger initial frame
     timeline.seekToKeyIndex(0);
 
-    stopRenderLoop = startRenderLoop(scene, camera, renderer, controls, labelRenderer);
+    // --- Render loop — single RAF for all bundles ---
+    const bundles = [topDownBundle, depthBundle].filter(Boolean);
+    stopLoop = startRenderLoop(bundles);
+
+    // --- Auto-load video ---
+    probeVideoUrl('spatial_annotated.mp4').then(url => {
+      if (url) videoPanel.loadVideo(url);
+    });
+
   } catch (err) {
     console.error('Failed to initialize viewer:', err);
     document.getElementById('status').textContent = `Error: ${err.message}`;
@@ -140,7 +184,7 @@ function initViewer(data) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  // File input handler
+  // JSON file input
   document.getElementById('file-input').addEventListener('change', async (e) => {
     const file = e.target.files[0];
     if (!file) return;
@@ -153,7 +197,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  // Try auto-loading spatial_results.json
+  // Video file input
+  document.getElementById('video-input').addEventListener('change', (e) => {
+    const file = e.target.files[0];
+    if (!file || !videoPanel) return;
+    videoPanel.loadVideo(file);
+  });
+
+  // Auto-load spatial_results.json
   loadData('spatial_results.json')
     .then(data => initViewer(data))
     .catch(err => {

--- a/viewer/js/data-loader.js
+++ b/viewer/js/data-loader.js
@@ -44,3 +44,14 @@ export function getMetadata(data) {
 export function getZones(data) {
   return data.zones || [];
 }
+
+/**
+ * Attempt to load a video URL. Returns the URL if it exists, null otherwise.
+ */
+export async function probeVideoUrl(url) {
+  try {
+    const resp = await fetch(url, { method: 'HEAD' });
+    if (resp.ok) return url;
+  } catch { /* ignore */ }
+  return null;
+}

--- a/viewer/js/scene.js
+++ b/viewer/js/scene.js
@@ -5,20 +5,38 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { CSS2DRenderer } from 'three/addons/renderers/CSS2DRenderer.js';
 
+/**
+ * Legacy wrapper — keeps old call-sites working.
+ */
 export function createScene(container, width, height, signal, { hasCamera = false } = {}) {
+  return createSceneBundle(container, width, height, signal, {
+    mode: hasCamera ? 'perspective' : 'orthographic',
+  });
+}
+
+/**
+ * Create a self-contained { scene, camera, renderer, controls, labelRenderer }
+ * bundle inside the given container.
+ *
+ * @param {HTMLElement} container
+ * @param {number} width   - scene width (pixels from metadata)
+ * @param {number} height  - scene height (pixels from metadata)
+ * @param {AbortSignal} signal
+ * @param {object} options
+ * @param {'orthographic'|'perspective'} options.mode
+ */
+export function createSceneBundle(container, width, height, signal, { mode = 'orthographic' } = {}) {
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0x0f172a);
 
-  const aspect = container.clientWidth / container.clientHeight;
+  const aspect = container.clientWidth / (container.clientHeight || 1);
   let camera;
 
-  if (hasCamera) {
-    // Perspective camera for 3D depth mode — better depth perception
+  if (mode === 'perspective') {
     camera = new THREE.PerspectiveCamera(60, aspect, 1, 5000);
     camera.position.set(0, Math.max(width, height) * 0.8, Math.max(width, height) * 0.6);
     camera.lookAt(0, 0, 0);
   } else {
-    // Orthographic camera — top-down view for flat mode
     const frustumSize = Math.max(width, height) * 0.6;
     camera = new THREE.OrthographicCamera(
       -frustumSize * aspect, frustumSize * aspect,
@@ -31,13 +49,13 @@ export function createScene(container, width, height, signal, { hasCamera = fals
 
   // WebGL renderer
   const renderer = new THREE.WebGLRenderer({ antialias: true });
-  renderer.setSize(container.clientWidth, container.clientHeight);
+  renderer.setSize(container.clientWidth, container.clientHeight || 1);
   renderer.setPixelRatio(window.devicePixelRatio);
   container.appendChild(renderer.domElement);
 
   // CSS2D renderer for labels
   const labelRenderer = new CSS2DRenderer();
-  labelRenderer.setSize(container.clientWidth, container.clientHeight);
+  labelRenderer.setSize(container.clientWidth, container.clientHeight || 1);
   labelRenderer.domElement.style.position = 'absolute';
   labelRenderer.domElement.style.top = '0';
   labelRenderer.domElement.style.left = '0';
@@ -46,10 +64,14 @@ export function createScene(container, width, height, signal, { hasCamera = fals
 
   // Controls
   const controls = new OrbitControls(camera, renderer.domElement);
-  controls.enableRotate = true;
   controls.enablePan = true;
   controls.enableZoom = true;
-  controls.maxPolarAngle = Math.PI / 2;
+  if (mode === 'orthographic') {
+    controls.enableRotate = false; // top-down: pan + zoom only
+  } else {
+    controls.enableRotate = true;
+    controls.maxPolarAngle = Math.PI / 2;
+  }
 
   // Lights
   scene.add(new THREE.AmbientLight(0xffffff, 0.6));
@@ -57,10 +79,10 @@ export function createScene(container, width, height, signal, { hasCamera = fals
   dirLight.position.set(100, 300, 100);
   scene.add(dirLight);
 
-  // Resize handler
-  const onResize = () => {
+  // Per-container ResizeObserver (not window.resize)
+  const ro = new ResizeObserver(() => {
     const w = container.clientWidth;
-    const h = container.clientHeight;
+    const h = container.clientHeight || 1;
     const a = w / h;
     if (camera.isPerspectiveCamera) {
       camera.aspect = a;
@@ -74,19 +96,38 @@ export function createScene(container, width, height, signal, { hasCamera = fals
     camera.updateProjectionMatrix();
     renderer.setSize(w, h);
     labelRenderer.setSize(w, h);
-  };
-  window.addEventListener('resize', onResize, { signal });
+  });
+  ro.observe(container);
+
+  // Disconnect on abort
+  if (signal) {
+    signal.addEventListener('abort', () => ro.disconnect(), { once: true });
+  }
 
   return { scene, camera, renderer, controls, labelRenderer };
 }
 
-export function startRenderLoop(scene, camera, renderer, controls, labelRenderer) {
+/**
+ * Single RAF loop that renders an array of scene bundles.
+ * Returns a stop function.
+ *
+ * @param {Array<{scene, camera, renderer, controls, labelRenderer}>} bundles
+ */
+export function startRenderLoop(bundles) {
+  // Accept legacy positional args: (scene, camera, renderer, controls, labelRenderer)
+  if (!Array.isArray(bundles)) {
+    const [scene, camera, renderer, controls, labelRenderer] = arguments;
+    bundles = [{ scene, camera, renderer, controls, labelRenderer }];
+  }
+
   let rafId = null;
   function animate() {
     rafId = requestAnimationFrame(animate);
-    controls.update();
-    renderer.render(scene, camera);
-    labelRenderer.render(scene, camera);
+    for (const b of bundles) {
+      b.controls.update();
+      b.renderer.render(b.scene, b.camera);
+      b.labelRenderer.render(b.scene, b.camera);
+    }
   }
   animate();
   return () => { if (rafId) cancelAnimationFrame(rafId); };

--- a/viewer/js/scene.js
+++ b/viewer/js/scene.js
@@ -6,15 +6,6 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { CSS2DRenderer } from 'three/addons/renderers/CSS2DRenderer.js';
 
 /**
- * Legacy wrapper — keeps old call-sites working.
- */
-export function createScene(container, width, height, signal, { hasCamera = false } = {}) {
-  return createSceneBundle(container, width, height, signal, {
-    mode: hasCamera ? 'perspective' : 'orthographic',
-  });
-}
-
-/**
  * Create a self-contained { scene, camera, renderer, controls, labelRenderer }
  * bundle inside the given container.
  *
@@ -114,12 +105,6 @@ export function createSceneBundle(container, width, height, signal, { mode = 'or
  * @param {Array<{scene, camera, renderer, controls, labelRenderer}>} bundles
  */
 export function startRenderLoop(bundles) {
-  // Accept legacy positional args: (scene, camera, renderer, controls, labelRenderer)
-  if (!Array.isArray(bundles)) {
-    const [scene, camera, renderer, controls, labelRenderer] = arguments;
-    bundles = [{ scene, camera, renderer, controls, labelRenderer }];
-  }
-
   let rafId = null;
   function animate() {
     rafId = requestAnimationFrame(animate);

--- a/viewer/js/video-panel.js
+++ b/viewer/js/video-panel.js
@@ -31,6 +31,14 @@ export class VideoPanel {
   loadVideo(source) {
     this._revokeBlobUrl();
 
+    this.video.onerror = () => {
+      const code = this.video.error ? this.video.error.code : 'unknown';
+      console.error(`Video load failed (code=${code})`);
+      this.video.classList.remove('video-loaded');
+      this.placeholder.style.display = '';
+      this.placeholder.textContent = `Video failed to load (error ${code})`;
+    };
+
     if (source instanceof File) {
       this.blobUrl = URL.createObjectURL(source);
       this.video.src = this.blobUrl;
@@ -40,14 +48,6 @@ export class VideoPanel {
 
     this.video.classList.add('video-loaded');
     this.placeholder.style.display = 'none';
-
-    this.video.onerror = () => {
-      const code = this.video.error ? this.video.error.code : 'unknown';
-      console.error(`Video load failed (code=${code})`);
-      this.video.classList.remove('video-loaded');
-      this.placeholder.style.display = '';
-      this.placeholder.textContent = `Video failed to load (error ${code})`;
-    };
   }
 
   /**

--- a/viewer/js/video-panel.js
+++ b/viewer/js/video-panel.js
@@ -1,0 +1,71 @@
+/**
+ * Video panel with frame-synced seeking for the DINO Spatial Viewer.
+ */
+
+export class VideoPanel {
+  constructor(container, metadata) {
+    this.container = container;
+    this.metadata = metadata;
+    this.video = null;
+    this.blobUrl = null;
+
+    this._buildDOM();
+  }
+
+  _buildDOM() {
+    // Placeholder shown when no video is loaded
+    this.placeholder = document.createElement('div');
+    this.placeholder.style.cssText =
+      'display:flex;align-items:center;justify-content:center;width:100%;height:100%;color:#475569;font-size:13px;text-align:center;';
+    this.placeholder.textContent = 'No video loaded — use Load Video';
+    this.container.appendChild(this.placeholder);
+
+    // Video element (hidden until loaded)
+    this.video = document.createElement('video');
+    this.video.muted = true;
+    this.video.playsInline = true;
+    this.video.style.cssText =
+      'display:none;width:100%;height:100%;object-fit:contain;background:#000;';
+    this.container.appendChild(this.video);
+  }
+
+  /**
+   * Load a video from a File object or a URL string.
+   */
+  loadVideo(source) {
+    this._revokeBlobUrl();
+
+    if (source instanceof File) {
+      this.blobUrl = URL.createObjectURL(source);
+      this.video.src = this.blobUrl;
+    } else {
+      this.video.src = source;
+    }
+
+    this.video.style.display = 'block';
+    this.placeholder.style.display = 'none';
+  }
+
+  /**
+   * Seek the video to match the given frame index.
+   */
+  seekToFrame(frameIdx, _frameData) {
+    if (!this.video.src) return;
+    const fps = this.metadata.fps * (this.metadata.stride || 1);
+    this.video.currentTime = frameIdx / fps;
+  }
+
+  _revokeBlobUrl() {
+    if (this.blobUrl) {
+      URL.revokeObjectURL(this.blobUrl);
+      this.blobUrl = null;
+    }
+  }
+
+  dispose() {
+    this.video.pause();
+    this.video.removeAttribute('src');
+    this.video.load();
+    this._revokeBlobUrl();
+  }
+}

--- a/viewer/js/video-panel.js
+++ b/viewer/js/video-panel.js
@@ -13,19 +13,15 @@ export class VideoPanel {
   }
 
   _buildDOM() {
-    // Placeholder shown when no video is loaded
     this.placeholder = document.createElement('div');
-    this.placeholder.style.cssText =
-      'display:flex;align-items:center;justify-content:center;width:100%;height:100%;color:#475569;font-size:13px;text-align:center;';
+    this.placeholder.className = 'video-placeholder';
     this.placeholder.textContent = 'No video loaded — use Load Video';
     this.container.appendChild(this.placeholder);
 
-    // Video element (hidden until loaded)
     this.video = document.createElement('video');
+    this.video.className = 'video-element';
     this.video.muted = true;
     this.video.playsInline = true;
-    this.video.style.cssText =
-      'display:none;width:100%;height:100%;object-fit:contain;background:#000;';
     this.container.appendChild(this.video);
   }
 
@@ -42,8 +38,16 @@ export class VideoPanel {
       this.video.src = source;
     }
 
-    this.video.style.display = 'block';
+    this.video.classList.add('video-loaded');
     this.placeholder.style.display = 'none';
+
+    this.video.onerror = () => {
+      const code = this.video.error ? this.video.error.code : 'unknown';
+      console.error(`Video load failed (code=${code})`);
+      this.video.classList.remove('video-loaded');
+      this.placeholder.style.display = '';
+      this.placeholder.textContent = `Video failed to load (error ${code})`;
+    };
   }
 
   /**

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -125,6 +125,29 @@ button:hover {
   background: #a78bfa;
 }
 
+.video-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  color: #475569;
+  font-size: 13px;
+  text-align: center;
+}
+
+.video-element {
+  display: none;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background: #000;
+}
+
+.video-element.video-loaded {
+  display: block;
+}
+
 #time-display,
 #event-count {
   color: #94a3b8;

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -30,8 +30,42 @@ h1 {
   margin: 0;
 }
 
-#scene-container {
+#viewport-strip {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 2px;
+  overflow: hidden;
+}
+
+#viewport-strip.two-col {
+  grid-template-columns: 1fr 1fr;
+}
+
+#viewport-strip.two-col #panel-depth {
+  display: none;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.panel-label {
+  background: #1e293b;
+  color: #94a3b8;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 4px 8px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.panel-content {
   position: relative;
+  flex: 1;
   overflow: hidden;
 }
 
@@ -85,6 +119,10 @@ button:hover {
 
 .file-input-label input {
   display: none;
+}
+
+.file-input-video {
+  background: #a78bfa;
 }
 
 #time-display,


### PR DESCRIPTION
## Summary
- Add 3-panel surveillance-dashboard layout: annotation (video), top-down (orthographic), 3D depth (perspective)
- Panels adapt automatically: 3 columns with `metadata.camera`, 2 columns without
- Single RAF render loop drives all Three.js scenes; per-panel ResizeObserver for responsive sizing
- Video panel syncs frame-accurately to timeline scrubber/play/step controls

## Changes
| File | What |
|------|------|
| `viewer/index.html` | 3-panel HTML structure, video file input button |
| `viewer/style.css` | Grid layout, panel labels, 2/3-col toggle |
| `viewer/js/scene.js` | `createSceneBundle()` with mode param, ResizeObserver, multi-bundle render loop |
| `viewer/js/video-panel.js` | NEW — video element with frame-synced seeking |
| `viewer/js/app.js` | Multi-panel orchestration, fan-out frame changes |
| `viewer/js/data-loader.js` | `probeVideoUrl()` for auto-loading video |

## Test plan
- [ ] `cd viewer && python3 serve.py`, open http://localhost:8080
- [ ] Place `spatial_results.json` and `spatial_annotated.mp4` in `viewer/`
- [ ] Verify 3 panels when JSON has `metadata.camera`
- [ ] Verify 2 panels (no 3D) when `metadata.camera` is null
- [ ] Verify video syncs to timeline scrubber/play/step
- [ ] Verify top-down shows zones + object dots
- [ ] Verify 3D shows depth positions + camera frustum
- [ ] Verify orbit controls work independently per panel
- [ ] Verify window resize adjusts all panels
- [ ] Verify file inputs for both JSON and video work

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)