### PR TITLE
feat: Gaussian Splatting viewer integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,11 @@ Thumbs.db
 
 # Jupyter
 .ipynb_checkpoints/
+
+# Large viewer assets (symlinked from output/)
+viewer/gaussian_splat.ply
+viewer/point_clouds.bin
+viewer/point_clouds.bin.gz
+viewer/*.mp4
+viewer/*.png
+output/

--- a/docs/3d-rendering-options.md
+++ b/docs/3d-rendering-options.md
@@ -1,0 +1,615 @@
+# 3D Environment Reconstruction Options for Spatial Video Viewer
+
+**Date**: 2026-03-05
+**Context**: Restaurant walkthrough video, 24 seconds, 720x1280, processed through DINO spatial pipeline
+**Current baseline**: Per-frame sparse point clouds (~13K points/frame) from Depth-Anything-V2-Small with ORB-based ego-motion, accumulated over a sliding window, rendered in Three.js
+
+---
+
+## Table of Contents
+
+1. [Current System Baseline](#1-current-system-baseline)
+2. [Gaussian Splatting (3DGS)](#2-gaussian-splatting-3dgs)
+3. [NeRF Variants](#3-nerf-variants)
+4. [TSDF Fusion](#4-tsdf-fusion)
+5. [Dense Monocular Depth Upgrades](#5-dense-monocular-depth-upgrades)
+6. [Textured Mesh Reconstruction](#6-textured-mesh-reconstruction)
+7. [Hybrid Approaches](#7-hybrid-approaches)
+8. [Recommendation Matrix](#8-recommendation-matrix)
+9. [Recommended Implementation Path](#9-recommended-implementation-path)
+
+---
+
+## 1. Current System Baseline
+
+**What we have today:**
+
+- **Depth model**: Depth-Anything-V2-Small (25M params, Apache 2.0 license)
+- **Depth type**: Relative (affine-invariant), normalized to [0, 1] per frame
+- **Point cloud**: ~13K points per frame, sampled on an 8-pixel grid from 720x1280 depth maps
+- **Ego-motion**: ORB feature matching with essential matrix decomposition
+- **Accumulation**: Sliding window of recent frames transformed to world coordinates
+- **Renderer**: Three.js `BufferGeometry` with `Points` material
+- **Writer**: Custom binary `.bin` format (see `depth_cloud_writer.py`)
+
+**Key limitations:**
+- Relative depth means no consistent scale across frames -- points "breathe" as depth normalization shifts
+- ORB ego-motion drifts over time, causing ghosting and misalignment
+- Sparse sampling (every 8th pixel) loses fine geometric detail
+- Point cloud rendering has visible gaps; no surface interpolation
+- No color/texture information in the point cloud
+
+---
+
+## 2. Gaussian Splatting (3DGS)
+
+### Overview
+
+3D Gaussian Splatting represents scenes as collections of 3D Gaussian primitives, each with position, covariance, color (via spherical harmonics), and opacity. Trained via differentiable rendering from multi-view images, it achieves photorealistic novel view synthesis at real-time frame rates.
+
+### Quality Level
+
+- **Photorealistic** for well-captured scenes with sufficient viewpoint coverage
+- Handles view-dependent effects (specular reflections on restaurant glass/metal)
+- Significantly superior to point clouds -- produces continuous, artifact-free renders
+- Quality degrades in regions with sparse viewpoint coverage (e.g., if the camera only passes through once in a straight line, side views will have artifacts)
+
+### Compute Requirements
+
+**COLMAP preprocessing (camera poses + sparse SfM):**
+- For a 24-second video at 30fps (~720 frames), COLMAP feature extraction + matching + bundle adjustment: **15-45 minutes** on RTX 3060
+- Can subsample to every 3rd-5th frame (~150-240 images) to speed up without significant quality loss
+- COLMAP is CPU-bound for bundle adjustment; GPU helps with feature extraction
+
+**3DGS training on RTX 3060 12GB:**
+- 30,000 iterations: ~30 minutes
+- 7,000-15,000 iterations (reduced, still good quality): ~10-15 minutes
+- VRAM usage: fits comfortably at 720p input resolution (auto-rescales if width > 1600px)
+- The 12GB VRAM on the 3060 is adequate for this scene scale
+
+**Cloud (A100/H100 on Modal):**
+- COLMAP: ~5-10 minutes
+- 3DGS training: ~5-8 minutes for 30K iterations
+- Total wall-clock including data upload: ~15-20 minutes
+
+### Three.js Viewer Integration
+
+Two mature Three.js Gaussian splat renderers exist:
+
+**[GaussianSplats3D](https://github.com/mkkellogg/GaussianSplats3D)** (Mark Kellogg):
+- Most mature and widely used Three.js 3DGS renderer
+- Supports `.ply`, `.splat`, and `.ksplat` (compressed) formats
+- Progressive loading support
+- CPU-based splat sorting (artifacts when moving fast, but acceptable for controlled viewpoints)
+- In-memory compression to reduce footprint
+- Integrates as a standard Three.js scene object
+
+**[Spark v2.0](https://github.com/sparkjsdev/spark)** (sparkjs.dev):
+- Newer, more advanced renderer with Level-of-Detail (LoD) streaming
+- Supports `.ply`, `.spz`, `.splat`, `.ksplat`, `.sog` formats
+- Designed for "huge worlds" with dynamic splats
+- Integrates into Three.js rendering pipeline, fusing splats with mesh objects
+- 98%+ WebGL2 device support
+- Better suited if we want to combine splats with other Three.js geometry (zone overlays, annotations)
+
+**Integration effort**: Medium. Both libraries provide npm packages. Load the exported `.ply`/`.splat` file, add to the Three.js scene, and the renderer handles the rest. The main work is replacing our current point cloud rendering code with the splat viewer component.
+
+### Dependencies and Setup
+
+- COLMAP (C++ build, or use `pycolmap` via pip)
+- Original 3DGS implementation (CUDA, Python, PyTorch) or nerfstudio's Splatfacto
+- `gsplat` library (nerfstudio's CUDA rasterizer) -- more memory efficient than original
+- Export via `ns-export gaussian-splat` or directly from original implementation
+
+### Pros
+- Best visual quality of any approach listed here
+- Real-time rendering in browser via WebGL
+- Mature ecosystem with multiple Three.js renderers
+- Can be trained on RTX 3060 in under an hour
+- Actively developed community with continuous improvements
+
+### Cons
+- **COLMAP dependency** is the biggest pain point -- can fail on textureless or repetitive regions (common in restaurants with uniform walls/floors)
+- Requires sufficient multi-view overlap; a single-pass walkthrough may not provide enough coverage for side-looking novel views
+- Training produces large files (~50-200MB for a scene this size)
+- CPU-based splat sorting in web renderers can cause frame drops during fast navigation
+- Overfitting risk with sequential video frames (too similar viewpoints)
+
+---
+
+## 3. NeRF Variants
+
+### Overview
+
+Neural Radiance Fields encode a scene as a neural network that maps 3D coordinates + viewing direction to color + density. Multiple variants exist with different speed/quality tradeoffs.
+
+### Nerfacto (nerfstudio's recommended method)
+
+**Quality**: Good for real-world scenes. Incorporates per-image appearance embeddings (handles exposure changes), hash-grid encoding from Instant-NGP, and predicted normals.
+
+**Training time on RTX 3060:**
+- ~12 minutes for a standard scene
+- Uses PyTorch (no custom CUDA required beyond tinycudann)
+- Render speed: ~1 FPS (not real-time)
+
+**Export options:**
+- Point cloud export (similar to what we have now, but denser)
+- Mesh export via marching cubes on the density field
+- Cannot directly export to Gaussian splats (one-way conversion exists: NeRF-to-3DGS)
+
+### Instant-NGP
+
+**Quality**: Comparable to Nerfacto but faster training. The hash-grid encoding enables training in seconds to minutes.
+
+**Compute**: Requires tinycudann (NVIDIA-only). RTX 3060 compatible. Training: 2-5 minutes.
+
+**Limitation**: Nerfstudio's implementation diverges from the original. The original Instant-NGP binary from NVIDIA is fast but less flexible.
+
+### Real-Time Rendering Problem
+
+The fundamental issue with NeRFs for our use case: **NeRFs cannot render in real-time in a web browser.** They require neural network inference per pixel per frame. Options:
+
+1. **Pre-render a fixed camera path** -- defeats the purpose of interactive exploration
+2. **Export to mesh** -- loses view-dependent effects, quality drops significantly
+3. **Convert NeRF to 3DGS** -- nerfstudio supports this (`nerf2gs`), but adds another conversion step
+4. **WebGL NeRF renderers** -- exist but are extremely slow (< 1 FPS) and impractical
+
+### Pros
+- Well-understood pipeline via nerfstudio
+- Nerfacto handles varying lighting/exposure well
+- Can export meshes for offline use
+- Lower memory footprint than 3DGS during training
+
+### Cons
+- **No practical real-time web rendering** -- this is a dealbreaker for our Three.js viewer
+- Mesh export quality is significantly lower than direct NeRF rendering
+- Still requires COLMAP for camera poses
+- Nerfstudio dependency stack is heavy (torch, tinycudann, nerfacc, etc.)
+- Converting NeRF to 3DGS adds complexity; better to train 3DGS directly
+
+### Verdict
+
+**Not recommended as a primary approach.** The lack of real-time web rendering makes NeRFs impractical for our interactive Three.js viewer. If real-time rendering is not needed (e.g., pre-rendered flythrough video), Nerfacto is a solid option, but 3DGS dominates for interactive use.
+
+---
+
+## 4. TSDF Fusion
+
+### Overview
+
+Truncated Signed Distance Function (TSDF) integration fuses multiple depth maps into a volumetric representation, then extracts a triangle mesh via Marching Cubes. This is the classical approach used by RGB-D reconstruction systems (KinectFusion, etc.).
+
+### Quality Level
+
+- Produces smooth, watertight triangle meshes
+- Quality depends entirely on input depth map quality and camera pose accuracy
+- With our current relative depth maps: **poor** (TSDF needs metric depth with consistent scale)
+- With metric depth models: **moderate to good** for geometry, texture quality depends on UV mapping
+- Thin structures (table legs, chair backs) are problematic -- TSDF has known issues with thin geometry
+- Not photorealistic -- produces a textured mesh, not radiance-field quality
+
+### Compute Requirements
+
+**Open3D TSDF integration:**
+- GPU-accelerated via Open3D's tensor API
+- Processing 720 frames of 720x1280 depth maps: ~2-5 minutes on RTX 3060
+- Marching Cubes mesh extraction: seconds
+- Voxel resolution tradeoff: finer voxels = more detail but more memory. At 1cm resolution, a restaurant-sized room (~10m x 10m x 3m) = ~300M voxels, which exceeds 12GB. Use 2-5cm voxels.
+- ~100Hz integration rate achievable on a GTX 1070 (faster on 3060)
+
+**Alternatives to Open3D:**
+- **voxblox** (C++, ROS-oriented): faster but harder to integrate with Python
+- **fVDB** (OpenVDB-based): sparse TSDF, more memory efficient for large scenes
+- **RGBTSDF**: improved texture quality via depth interpolation and texture constraints
+
+### Integration with Our Existing Pipeline
+
+This is the most straightforward upgrade path because:
+- We already produce depth maps per frame
+- We already have camera poses (ego-motion)
+- TSDF fusion directly consumes depth maps + poses
+- Output is a triangle mesh, which Three.js renders natively and efficiently
+
+**Critical prerequisite**: Our depth maps must be **metric** (consistent scale across frames). Our current relative depth normalization breaks TSDF fusion. We would need to upgrade to a metric depth model first (see Section 5).
+
+### Three.js Integration
+
+- Export mesh as `.glb`/`.gltf` with textures
+- Three.js `GLTFLoader` handles this natively
+- Mesh rendering is far more efficient than point clouds (GPU-optimized triangle rasterization)
+- Can add normal maps, ambient occlusion, etc. for enhanced visual quality
+- Supports LOD (level of detail) for large meshes
+
+### Dependencies
+
+- `open3d` (pip install, well-maintained)
+- Metric depth estimator (see Section 5)
+- MeshLab or Open3D for texture baking (optional)
+
+### Pros
+- Directly uses our existing depth map pipeline
+- Fast processing (minutes, not hours)
+- Output is standard triangle mesh -- trivial Three.js integration
+- Well-understood, mature technique
+- Low dependency count
+
+### Cons
+- Quality ceiling is lower than 3DGS or NeRF
+- Requires metric depth (upgrade from our current relative depth)
+- Texture quality depends on separate UV mapping/baking step
+- Thin structures and fine details are lost
+- Voxel resolution is a hard tradeoff between detail and memory
+- No view-dependent effects (no specular highlights, reflections)
+
+---
+
+## 5. Dense Monocular Depth Upgrades
+
+### Current State: Depth-Anything-V2-Small
+
+- 25M parameters, ViT-S backbone
+- Apache 2.0 license (commercial OK)
+- Relative/affine-invariant depth only
+- Fast inference, low VRAM usage
+- Good generalization but limited fine detail
+
+### Upgrade Option 1: Depth-Anything-V2-Large
+
+| Attribute | Small (current) | Large |
+|-----------|-----------------|-------|
+| Parameters | 25M | 335M |
+| License | Apache 2.0 | CC-BY-NC-4.0 (non-commercial) |
+| Depth quality | Good | Significantly better fine detail |
+| Inference speed (3060) | ~30ms/frame | ~150-200ms/frame |
+| VRAM | ~1GB | ~4-6GB |
+| Output type | Relative depth | Relative depth |
+
+**Verdict**: Easy swap (same API, just change `model_id`). Noticeably better depth maps. But still relative depth -- does not solve the scale consistency problem for TSDF or accumulated point clouds. The CC-BY-NC-4.0 license is a constraint if this becomes a commercial product.
+
+### Upgrade Option 2: Video Depth Anything (CVPR 2025 Highlight)
+
+This is the most relevant upgrade for our video pipeline:
+
+- Built on Depth-Anything-V2 with a **spatiotemporal head** that enforces temporal consistency
+- Processes arbitrarily long videos without quality degradation
+- **Key-frame-based inference strategy** for long videos
+- Smallest model runs at **30 FPS** in real-time
+- Achieves 0.944 delta-1 on KITTI vs. 0.815 for DAv2-Large
+- Temporal consistency (TAE): 0.570 on ScanNet vs. 1.140 for DAv2-Large (2x better)
+
+**Impact on our pipeline**: Would eliminate the "breathing" artifacts from per-frame depth normalization. Temporally consistent depth means accumulated point clouds align much better without explicit scale correction.
+
+**Compute**: Similar to DAv2-Large per frame, but processes video chunks for temporal modeling. RTX 3060 feasible with the Small variant.
+
+### Upgrade Option 3: Metric Depth Models
+
+For TSDF fusion or any approach requiring absolute scale:
+
+**ZoeDepth:**
+- Extends MiDaS with adaptive metric binning
+- Predicts metric depth with scene-aware routing (indoor/outdoor)
+- Requires camera intrinsics
+- Good zero-shot generalization
+- Moderate quality, showing its age (2023)
+
+**UniDepth / UniDepthV2 (2025):**
+- Predicts metric 3D point clouds without camera intrinsics (self-predicts camera parameters)
+- Best zero-shot cross-domain generalization
+- Outperforms Metric3D on NYU and KITTI benchmarks
+- ~3GB VRAM for inference
+- RTX 3060 feasible
+- V2 simplifies the architecture further
+
+**Metric3Dv2:**
+- Joint metric depth + surface normal estimation
+- Canonical camera space normalization (handles different focal lengths)
+- Champion of CVPR 2023 Monocular Depth Challenge
+- Slightly more efficient decoder than UniDepth
+- Requires more training data but produces normals (useful for mesh reconstruction)
+
+**Apple DepthPro:**
+- Pixel-perfect metric depth with sharp boundaries
+- Outperforms Metric3D v2 and Depth Anything on in-the-wild scenes
+- Higher compute cost
+- Apple license restrictions
+
+**Recommendation**: **UniDepthV2** for metric depth. No intrinsics required (simplifies our pipeline), best generalization, and RTX 3060 feasible. Combine with Video Depth Anything for temporal consistency if needed.
+
+### Upgrade Option 4: DUSt3R / MASt3R / MUSt3R
+
+These are not just depth estimators -- they are **multi-view geometric foundation models** that jointly solve depth, camera poses, and 3D reconstruction from unposed images.
+
+**DUSt3R** (2024):
+- Takes pairs of images, outputs dense 3D pointmaps
+- No camera calibration or poses needed
+- Pairwise only; requires global optimization for multi-view
+
+**MASt3R** (2024):
+- Adds metric pointmaps + matching head to DUSt3R
+- Handles thousands of images
+- 30% improvement over prior art on localization benchmarks
+
+**MUSt3R** (CVPR 2025):
+- Symmetric architecture, processes all views in a common frame directly
+- Multi-layer memory mechanism for scaling to large collections
+- Works both offline and online (visual SLAM compatible)
+- **High frame-rate inference** for thousands of pointmaps
+- State-of-the-art on visual odometry, relative pose, scale estimation, and multi-view depth
+
+**MV-DUSt3R+** (CVPR 2025):
+- Single-pass feed-forward for multiple views
+- Reconstructs a room from 12 views in 0.89 seconds, multi-room from 20 views in 1.54 seconds
+
+**Impact on our pipeline**: MUSt3R could **replace both our ego-motion estimation AND depth estimation** in one model. It would give us:
+- Metric-scale dense 3D pointmaps
+- Accurate camera poses (no ORB drift)
+- Multi-view consistent geometry
+
+**Compute on RTX 3060:**
+- DUSt3R/MASt3R: ~8-12GB VRAM for pairs of 512x512 images. Tight fit on 12GB 3060 at our resolution (720x1280 would need downsampling or tiling).
+- MUSt3R: similar baseline but more efficient for many views due to memory mechanism.
+- Processing 720 frames: subsample to ~50-100 keyframes, run pairwise or multi-view. Estimate: 10-30 minutes on 3060 depending on subsampling.
+- Cloud (A100): 2-5 minutes for the full sequence.
+
+### Processing Time Summary (24-second 720x1280 video, ~720 frames)
+
+| Model | RTX 3060 Time | Output |
+|-------|--------------|--------|
+| DAv2-Small (current) | ~22s (30ms/frame) | Relative depth |
+| DAv2-Large | ~2.5min (200ms/frame) | Relative depth, finer |
+| Video Depth Anything-S | ~30s | Temporally consistent relative depth |
+| Video Depth Anything-L | ~3min | Temporally consistent relative depth |
+| UniDepthV2 | ~3-5min | Metric depth + 3D points |
+| MUSt3R (50 keyframes) | ~15-30min | Metric pointmaps + poses |
+
+---
+
+## 6. Textured Mesh Reconstruction
+
+### Poisson Surface Reconstruction
+
+Given a dense, oriented point cloud, Poisson reconstruction produces a smooth, watertight triangle mesh.
+
+**Pipeline:**
+1. Generate dense point cloud (from upgraded depth or DUSt3R/MASt3R)
+2. Estimate + orient normals (Open3D `estimate_normals` + `orient_normals_consistent_tangent_plane`)
+3. Run Poisson reconstruction (`create_from_point_cloud_poisson`)
+4. Prune low-density vertices (remove spurious outer shell)
+5. Generate UV atlas (MeshLab or xatlas)
+6. Bake vertex colors / project images to texture atlas
+7. Export as `.glb` with texture
+
+**Quality**: Smooth surfaces, but Poisson always creates closed/watertight meshes which means phantom geometry where there are no observations. The density-based pruning step is critical but imperfect. Fine details are smoothed out.
+
+**Compute on RTX 3060:**
+- Point cloud generation: depends on depth model (see Section 5)
+- Poisson reconstruction: CPU-bound, 1-5 minutes for ~1M points (octree depth 10-12)
+- Texture baking: 2-10 minutes depending on atlas resolution
+
+### Ball Pivoting Algorithm (BPA)
+
+Alternative to Poisson that does not create closed meshes. Better for partial reconstructions (like a single-pass walkthrough where you only see one side of things). Available in Open3D and MeshLab.
+
+### Texture Mapping Approaches
+
+**Per-vertex coloring**: Simplest. Store RGB per vertex from the source image at back-projected pixel. No UV mapping needed. Three.js supports vertex colors natively. Quality is limited by mesh vertex density.
+
+**Texture atlas projection**: Project source images onto the mesh, stitching a texture atlas from the best-viewing-angle image per triangle. Higher quality but complex:
+- Requires accurate camera poses for reprojection
+- Seam artifacts at atlas boundaries
+- MeshLab's "Transfer: Vertex Attributes to Texture" filter handles this
+- Open3D does not have built-in texture atlas (requires external tools)
+
+**Neural texture baking**: Newer approaches (e.g., from nerfstudio mesh exports) can bake NeRF-quality colors into mesh textures, but this is more complex.
+
+### Three.js Rendering
+
+- `GLTFLoader` for `.glb` meshes with textures -- standard, well-optimized
+- `MeshStandardMaterial` with diffuse + normal maps
+- Orders of magnitude more efficient than point cloud rendering
+- Supports shadows, ambient occlusion, environment maps
+- LOD via `THREE.LOD` for performance optimization
+- Draco compression for mesh geometry (reduces file size 10-20x)
+
+### Pros
+- Standard triangle mesh -- universally supported, well-optimized rendering
+- Texture mapping provides decent visual quality
+- Small file sizes with Draco compression
+- Can add PBR materials for enhanced realism
+- Easy to integrate with existing Three.js scene (zone overlays, annotations, etc.)
+
+### Cons
+- Quality ceiling well below 3DGS
+- Poisson reconstruction artifacts (phantom geometry, over-smoothing)
+- Texture atlas generation is fiddly -- seams, blurring, projection errors
+- No view-dependent effects
+- Multiple tool pipeline (Open3D -> MeshLab -> export)
+- Quality highly dependent on input point cloud density and accuracy
+
+---
+
+## 7. Hybrid Approaches
+
+### Hybrid A: MUSt3R Poses + Gaussian Splatting (Recommended)
+
+**Pipeline:**
+1. Extract keyframes from video (~100-200 frames)
+2. Run MUSt3R for metric camera poses + dense pointmaps (replaces COLMAP)
+3. Initialize 3DGS with MUSt3R pointmaps as seed points
+4. Train Gaussian Splatting using MUSt3R poses
+5. Export `.ply`/`.splat` file
+6. Render in Three.js via GaussianSplats3D or Spark
+
+**Why this is compelling:**
+- Eliminates COLMAP entirely (the biggest pain point of standard 3DGS)
+- MUSt3R provides metric-scale poses and dense initialization
+- 3DGS provides photorealistic rendering
+- Both are actively developed (MUSt3R: CVPR 2025, Spark: 2025)
+
+**Prior art**: **InstantSplat** already demonstrated this approach with DUSt3R + 3DGS, achieving 30x speedup over COLMAP-based pipelines and building full scenes in under 1 minute. MUSt3R improves on DUSt3R with native multi-view support.
+
+**Compute (RTX 3060):**
+- MUSt3R pose estimation: 15-30 minutes
+- 3DGS training: 15-30 minutes
+- Total: ~30-60 minutes
+
+**Compute (A100 on Modal):**
+- MUSt3R: 2-5 minutes
+- 3DGS: 5-8 minutes
+- Total: ~10-15 minutes
+
+### Hybrid B: Video Depth Anything + TSDF Fusion (Quick Win)
+
+**Pipeline:**
+1. Run Video Depth Anything on the full video (temporally consistent depth)
+2. Use existing ORB ego-motion (or upgrade to MUSt3R poses)
+3. Feed depth maps + poses into Open3D TSDF integration
+4. Extract mesh via Marching Cubes
+5. Bake textures from source frames
+6. Load textured mesh in Three.js
+
+**Why this is compelling:**
+- Minimal changes to our existing pipeline (swap depth model, add TSDF step)
+- Video Depth Anything is a drop-in replacement for per-frame depth estimation
+- TSDF fusion is well-understood and fast
+- Produces a standard mesh that Three.js handles efficiently
+
+**Limitation**: Still relative depth (not metric) unless we add scale estimation. Temporal consistency helps but doesn't solve absolute scale. Could use UniDepthV2 instead for metric depth, but loses the temporal consistency advantage.
+
+**Compute (RTX 3060):**
+- Video Depth Anything: 30 seconds - 3 minutes
+- TSDF fusion: 2-5 minutes
+- Texture baking: 5-10 minutes
+- Total: ~10-20 minutes
+
+### Hybrid C: DUSt3R Dense Points + Poisson Mesh (Moderate Effort)
+
+**Pipeline:**
+1. Extract ~50-100 keyframes
+2. Run MASt3R/MUSt3R for dense metric pointmaps
+3. Merge pointmaps into unified point cloud
+4. Run Poisson surface reconstruction
+5. Texture atlas from source images
+6. Export to Three.js
+
+**Compute (RTX 3060):** 20-40 minutes total
+
+### Hybrid D: COLMAP-Free Gaussian Splatting (CF-3DGS)
+
+The CF-3DGS method (CVPR 2024) processes video frames sequentially, growing Gaussians without any SfM preprocessing. It estimates relative poses between consecutive frames using local Gaussian transformations.
+
+**Pros**: No COLMAP, no separate pose estimation step, processes video directly
+**Cons**: Quality slightly below COLMAP-initialized 3DGS, sequential processing is slower, less tested on long sequences
+
+---
+
+## 8. Recommendation Matrix
+
+| Approach | Quality | RTX 3060 Feasible | Processing Time (3060) | Viewer Integration | Setup Complexity | Priority |
+|----------|---------|-------------------|----------------------|-------------------|------------------|----------|
+| **3DGS (COLMAP)** | Excellent | Yes | 45-75 min | Easy (Spark/GS3D) | Medium (COLMAP) | 2 |
+| **Hybrid A: MUSt3R + 3DGS** | Excellent | Yes (tight) | 30-60 min | Easy (Spark/GS3D) | Medium | **1 (Top)** |
+| **Hybrid B: VDA + TSDF** | Good | Yes | 10-20 min | Trivial (GLTF) | Low | **1 (Quick win)** |
+| **NeRF (Nerfacto)** | Good | Yes | 15-20 min | Hard (no RT web) | Medium | 5 (Skip) |
+| **TSDF Fusion (metric depth)** | Moderate-Good | Yes | 10-15 min | Trivial (GLTF) | Low | 3 |
+| **Dense Depth Upgrade (VDA)** | Moderate | Yes | 1-3 min | Same as current | Trivial | **1 (First step)** |
+| **Textured Mesh (Poisson)** | Moderate | Yes | 20-40 min | Easy (GLTF) | Medium | 4 |
+| **Hybrid C: DUSt3R + Poisson** | Good | Yes | 20-40 min | Easy (GLTF) | Medium | 3 |
+| **CF-3DGS** | Good-Excellent | Yes | 45-90 min | Easy (Spark/GS3D) | Medium | 3 |
+
+**Quality scale**: Moderate < Good < Excellent (photorealistic)
+
+---
+
+## 9. Recommended Implementation Path
+
+### Phase 1: Immediate Upgrade (1-2 days effort)
+
+**Swap Depth-Anything-V2-Small for Video Depth Anything.**
+
+This is the lowest-effort, highest-impact change:
+- Drop-in model swap in `depth_estimator.py`
+- Temporally consistent depth maps eliminate "breathing" artifacts
+- Immediate visible improvement in accumulated point cloud quality
+- No pipeline architecture changes required
+- RTX 3060: processes full 24s video in under 3 minutes
+
+Code change in `src/dino/spatial/depth_estimator.py`:
+```python
+# Change from:
+DEFAULT_MODEL = "depth-anything/Depth-Anything-V2-Small-hf"
+# To:
+DEFAULT_MODEL = "depth-anything/Video-Depth-Anything-Small-hf"  # or equivalent
+```
+
+Also consider increasing point density by reducing `grid_step` from 8 to 4 in `depth_cloud_writer.py` (4x more points, ~52K per frame).
+
+### Phase 2: Mesh Upgrade (3-5 days effort)
+
+**Add TSDF fusion to produce textured meshes.**
+
+- Add Open3D TSDF integration step after depth estimation
+- Use Video Depth Anything output (or switch to UniDepthV2 for metric depth)
+- Extract mesh via Marching Cubes
+- Bake textures from source video frames
+- Export as `.glb`, load with Three.js `GLTFLoader`
+- Massive rendering performance improvement (mesh vs. point cloud)
+- Good visual quality, standard format
+
+### Phase 3: Photorealistic Rendering (1-2 weeks effort)
+
+**Implement MUSt3R + Gaussian Splatting hybrid pipeline.**
+
+- Replace ORB ego-motion with MUSt3R pose estimation
+- Use MUSt3R dense pointmaps to initialize 3DGS
+- Train Gaussian Splatting (via nerfstudio Splatfacto or original implementation)
+- Export `.splat`/`.ply` file
+- Integrate Spark v2.0 or GaussianSplats3D into Three.js viewer
+- This achieves the "DIMENSIONAL spatial-computing" level of fidelity
+
+**Cloud acceleration option**: Run MUSt3R + 3DGS training on Modal (A100) for ~10-15 minute turnaround. Use RTX 3060 for development/iteration.
+
+### Phase 4: Polish (ongoing)
+
+- Implement LOD streaming (Spark v2.0) for mobile/low-end devices
+- Add scene editing capabilities (SuperSplat for cleaning up artifacts)
+- Investigate NoPoSplat (ICLR 2025) for instant pose-free reconstruction
+- Consider MV-DUSt3R+ for sub-second multi-view reconstruction as models improve
+
+---
+
+## References
+
+### Gaussian Splatting & Viewers
+- [GaussianSplats3D](https://github.com/mkkellogg/GaussianSplats3D) -- Three.js 3DGS renderer
+- [Spark v2.0](https://github.com/sparkjsdev/spark) -- Advanced Three.js 3DGS with LoD streaming
+- [Original 3DGS](https://github.com/graphdeco-inria/gaussian-splatting) -- INRIA reference implementation
+- [gsplat](https://github.com/nerfstudio-project/gsplat) -- Nerfstudio's CUDA rasterizer
+- [Splatfacto](https://docs.nerf.studio/nerfology/methods/splat.html) -- Nerfstudio's 3DGS method
+
+### NeRF
+- [Nerfstudio](https://docs.nerf.studio/) -- Modular NeRF framework
+- [Nerfacto](https://docs.nerf.studio/nerfology/methods/nerfacto.html) -- Nerfstudio's recommended method
+
+### Multi-View Stereo (DUSt3R family)
+- [DUSt3R](https://arxiv.org/abs/2312.14132) -- Dense Unconstrained Stereo 3D Reconstruction
+- [MASt3R](https://europe.naverlabs.com/blog/mast3r-matching-and-stereo-3d-reconstruction/) -- Matching And Stereo 3D Reconstruction
+- [MUSt3R](https://arxiv.org/abs/2503.01661) -- Multi-view Network for Stereo 3D Reconstruction (CVPR 2025)
+- [MV-DUSt3R+](https://mv-dust3rp.github.io/) -- Multi-view extension (CVPR 2025)
+- [InstantSplat](https://arxiv.org/abs/2403.20309) -- DUSt3R + 3DGS hybrid
+
+### Depth Estimation
+- [Depth-Anything-V2](https://github.com/DepthAnything/Depth-Anything-V2) -- Foundation depth model
+- [Video Depth Anything](https://github.com/DepthAnything/Video-Depth-Anything) -- Temporally consistent video depth (CVPR 2025)
+- [UniDepth](https://github.com/lpiccinelli-eth/UniDepth) -- Universal metric depth
+- [Metric3Dv2](https://github.com/YvanYin/Metric3D) -- Metric depth + normals
+- [DepthPro](https://learnopencv.com/depth-pro-monocular-metric-depth/) -- Apple's metric depth
+
+### COLMAP-Free Methods
+- [CF-3DGS](https://arxiv.org/abs/2312.07504) -- COLMAP-Free 3D Gaussian Splatting (CVPR 2024)
+- [NoPoSplat](https://proceedings.iclr.cc/paper_files/paper/2025/file/857b34d81f0a8bfe3e18879dee3b5086-Paper-Conference.pdf) -- Pose-free Gaussian Splatting (ICLR 2025)
+
+### TSDF & Mesh Reconstruction
+- [Open3D TSDF Integration](https://www.open3d.org/docs/release/tutorial/t_reconstruction_system/integration.html)
+- [Open3D Surface Reconstruction](https://www.open3d.org/docs/latest/tutorial/Advanced/surface_reconstruction.html)
+- [RGBTSDF](https://www.mdpi.com/2072-4292/16/17/3188) -- Improved color TSDF fusion

--- a/modal_gaussian_splat.py
+++ b/modal_gaussian_splat.py
@@ -1,0 +1,180 @@
+"""Modal script: Gaussian Splatting from a restaurant walkthrough video.
+
+Uses the original 3DGS implementation (graphdeco-inria/gaussian-splatting)
+which has its own CUDA rasterizer and avoids gsplat compatibility issues.
+
+Uploads video → extracts frames → COLMAP → 3DGS train → exports .ply
+All on a Modal A100 GPU. Downloads result locally.
+
+Usage:
+    modal run modal_gaussian_splat.py --video /Users/heng/Downloads/test_rest.mp4
+"""
+import modal
+from pathlib import Path
+
+app = modal.App("gaussian-splat")
+
+# Build image: CUDA 11.8 + COLMAP + original 3DGS repo
+gs_image = (
+    modal.Image.from_registry("nvidia/cuda:11.8.0-devel-ubuntu22.04", add_python="3.10")
+    .apt_install("git", "ffmpeg", "colmap", "imagemagick", "g++", "ninja-build")
+    .env({"TORCH_CUDA_ARCH_LIST": "8.0", "CC": "gcc", "CXX": "g++"})
+    .run_commands(
+        "pip install torch torchvision --index-url https://download.pytorch.org/whl/cu118"
+        " && pip install plyfile tqdm Pillow numpy setuptools wheel opencv-python-headless"
+        " && git clone --recursive https://github.com/graphdeco-inria/gaussian-splatting.git /opt/gaussian-splatting"
+        " && pip install --no-build-isolation /opt/gaussian-splatting/submodules/diff-gaussian-rasterization"
+        " && pip install --no-build-isolation /opt/gaussian-splatting/submodules/simple-knn"
+    )
+)
+
+vol = modal.Volume.from_name("gs-workspace", create_if_missing=True)
+VOLUME_PATH = "/workspace"
+
+
+@app.function(
+    image=gs_image,
+    gpu="A100",
+    timeout=2400,  # 40 min
+    volumes={VOLUME_PATH: vol},
+)
+def train_gaussian_splat(video_bytes: bytes, video_name: str = "input.mp4"):
+    """Full pipeline: frames → COLMAP → 3DGS train → .ply export."""
+    import subprocess
+    import shutil
+
+    work = Path(VOLUME_PATH) / "gs_run"
+    if work.exists():
+        shutil.rmtree(work)
+    work.mkdir(parents=True)
+
+    # 1. Save video
+    video_path = work / video_name
+    video_path.write_bytes(video_bytes)
+    print(f"[1/5] Video saved: {len(video_bytes)/1024/1024:.1f}MB")
+
+    # 2. Extract frames (5fps, 800px wide)
+    input_dir = work / "input"
+    input_dir.mkdir()
+    subprocess.run([
+        "ffmpeg", "-i", str(video_path),
+        "-vf", "fps=5,scale=800:-2",
+        "-q:v", "2",
+        str(input_dir / "frame_%04d.jpg"),
+    ], check=True, capture_output=True)
+    n = len(list(input_dir.glob("*.jpg")))
+    print(f"[2/5] Extracted {n} frames")
+
+    # 3. Run COLMAP (the 3DGS repo expects a specific directory structure)
+    # Structure: <project>/input/<images>  →  COLMAP outputs to <project>/sparse/0/
+    sparse_dir = work / "sparse" / "0"
+    sparse_dir.mkdir(parents=True)
+    db_path = work / "database.db"
+
+    # Feature extraction
+    result = subprocess.run([
+        "colmap", "feature_extractor",
+        "--database_path", str(db_path),
+        "--image_path", str(input_dir),
+        "--ImageReader.single_camera", "1",
+        "--SiftExtraction.use_gpu", "0",
+    ], capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Feature extraction stderr: {result.stderr[-2000:]}")
+        raise RuntimeError("COLMAP feature extraction failed")
+    print("[3/5] COLMAP feature extraction done")
+
+    # Matching
+    result = subprocess.run([
+        "colmap", "sequential_matcher",
+        "--database_path", str(db_path),
+        "--SiftMatching.use_gpu", "0",
+    ], capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Matching stderr: {result.stderr[-2000:]}")
+        raise RuntimeError("COLMAP matching failed")
+    print("       COLMAP matching done")
+
+    # Sparse reconstruction
+    result = subprocess.run([
+        "colmap", "mapper",
+        "--database_path", str(db_path),
+        "--image_path", str(input_dir),
+        "--output_path", str(work / "sparse"),
+    ], capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Mapper stderr: {result.stderr[-2000:]}")
+        raise RuntimeError("COLMAP mapper failed")
+    print("       COLMAP reconstruction done")
+
+    # Undistort images (3DGS expects undistorted images)
+    result = subprocess.run([
+        "colmap", "image_undistorter",
+        "--image_path", str(input_dir),
+        "--input_path", str(sparse_dir),
+        "--output_path", str(work / "undistorted"),
+        "--output_type", "COLMAP",
+    ], capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Undistort stderr: {result.stderr[-2000:]}")
+        raise RuntimeError("COLMAP undistortion failed")
+
+    # Move undistorted output to where 3DGS expects it
+    undist = work / "undistorted"
+    # 3DGS expects: <source>/images/ and <source>/sparse/0/
+    # undistorter outputs: <output>/images/ and <output>/sparse/
+    if (undist / "sparse").exists():
+        target_sparse = undist / "sparse" / "0"
+        if not target_sparse.exists():
+            # Move contents into 0/ subdirectory if needed
+            target_sparse.mkdir(parents=True)
+            for f in (undist / "sparse").iterdir():
+                if f.is_file():
+                    shutil.move(str(f), str(target_sparse / f.name))
+    print("[4/5] COLMAP pipeline complete")
+
+    # 4. Train 3DGS
+    output_dir = work / "output"
+    result = subprocess.run([
+        "python", "/opt/gaussian-splatting/train.py",
+        "-s", str(undist),
+        "-m", str(output_dir),
+        "--iterations", "7000",
+    ], capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Train stdout: {result.stdout[-3000:]}")
+        print(f"Train stderr: {result.stderr[-3000:]}")
+        raise RuntimeError("3DGS training failed")
+    print("[5/5] Training done")
+
+    # 5. Find the output .ply
+    ply_path = output_dir / "point_cloud" / "iteration_7000" / "point_cloud.ply"
+    if not ply_path.exists():
+        # Try other iteration counts
+        plys = list(output_dir.rglob("point_cloud.ply"))
+        if not plys:
+            raise RuntimeError("No point_cloud.ply found")
+        ply_path = plys[-1]  # Take the last (highest iteration)
+
+    out_bytes = ply_path.read_bytes()
+    print(f"Export: {ply_path.name} ({len(out_bytes)/1024/1024:.1f}MB)")
+
+    vol.commit()
+    return out_bytes, "point_cloud.ply"
+
+
+@app.local_entrypoint()
+def main(video: str = "/Users/heng/Downloads/test_rest.mp4"):
+    """Upload video, train on A100, download .ply."""
+    p = Path(video)
+    if not p.exists():
+        raise FileNotFoundError(f"Not found: {video}")
+
+    print(f"Uploading {p.name} ({p.stat().st_size/1024/1024:.1f}MB)...")
+    data, name = train_gaussian_splat.remote(p.read_bytes(), p.name)
+
+    out_dir = Path("/Users/heng/Development/DINO/output/gaussian_splat")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / name
+    out_path.write_bytes(data)
+    print(f"Saved: {out_path} ({len(data)/1024/1024:.1f}MB)")

--- a/src/dino/detectors/grounding_dino.py
+++ b/src/dino/detectors/grounding_dino.py
@@ -102,25 +102,40 @@ class GroundingDINODetector(BaseDetector):
 
         boxes = results["boxes"].cpu().numpy()
         scores = results["scores"].cpu().numpy()
-        labels = results["labels"]
+        # Use text_labels (new key) with fallback to labels (deprecated)
+        labels = results.get("text_labels", results.get("labels", []))
+
+        # Ensure consistent lengths — post-processor can return mismatched arrays
+        n_boxes = len(boxes)
+        if len(labels) != n_boxes or len(scores) != n_boxes:
+            min_len = min(n_boxes, len(scores), len(labels))
+            boxes = boxes[:min_len]
+            scores = scores[:min_len]
+            labels = labels[:min_len]
+
+        if not labels:
+            return sv.Detections.empty()
 
         raw_class_ids = np.array(
             [self._label_to_class_id(label, prompts) for label in labels],
             dtype=int,
-        ) if labels else np.array([], dtype=int)
+        )
 
         mask = raw_class_ids >= 0
-        if len(mask) > 0 and not mask.all():
+        if not mask.all():
             boxes = boxes[mask]
             scores = scores[mask]
             labels = [l for l, m in zip(labels, mask) if m]
             raw_class_ids = raw_class_ids[mask]
 
+        if len(boxes) == 0:
+            return sv.Detections.empty()
+
         return sv.Detections(
             xyxy=boxes,
             confidence=scores,
             class_id=raw_class_ids,
-            data={"class_name": np.array(labels) if labels else np.array([])},
+            data={"class_name": np.array(labels)},
         )
 
     @staticmethod

--- a/src/dino/spatial/depth_cloud_writer.py
+++ b/src/dino/spatial/depth_cloud_writer.py
@@ -27,7 +27,7 @@ class DepthCloudWriter:
         output_path: str | Path,
         intrinsics: CameraIntrinsics,
         pose_matrix: np.ndarray,
-        grid_step: int = 4,
+        grid_step: int = 8,
     ):
         self.output_path = Path(output_path)
         self.intrinsics = intrinsics

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -33,13 +33,13 @@
         <div class="panel-label">Annotation</div>
         <div class="panel-content" id="annotation-content"></div>
       </div>
+      <div class="panel panel-center" id="panel-depth">
+        <div class="panel-label">3D Point Cloud</div>
+        <div class="panel-content" id="depth-content"></div>
+      </div>
       <div class="panel" id="panel-topdown">
         <div class="panel-label">Top-down</div>
         <div class="panel-content" id="topdown-content"></div>
-      </div>
-      <div class="panel" id="panel-depth">
-        <div class="panel-label">3D Depth</div>
-        <div class="panel-content" id="depth-content"></div>
       </div>
     </main>
     <footer id="timeline-bar">

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -8,8 +8,9 @@
   <script type="importmap">
   {
     "imports": {
-      "three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/"
+      "three": "https://cdn.jsdelivr.net/npm/three@0.178.0/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.178.0/examples/jsm/",
+      "@sparkjsdev/spark": "https://sparkjs.dev/releases/spark/0.1.10/spark.module.js"
     }
   }
   </script>
@@ -34,7 +35,7 @@
         <div class="panel-content" id="annotation-content"></div>
       </div>
       <div class="panel panel-center" id="panel-depth">
-        <div class="panel-label">3D Point Cloud</div>
+        <div class="panel-label">3D Gaussian Splat</div>
         <div class="panel-content" id="depth-content"></div>
       </div>
       <div class="panel" id="panel-topdown">

--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -6,7 +6,6 @@ import { createSceneBundle, startRenderLoop } from './scene.js';
 import { createFloorPlan } from './floor-plan.js';
 import { ZoneRenderer } from './zone-renderer.js';
 import { ObjectRenderer } from './object-renderer.js';
-import { CameraRenderer } from './camera-renderer.js';
 import { CameraTrail } from './camera-trail.js';
 import { PointCloudRenderer } from './point-cloud-renderer.js';
 import { Timeline } from './timeline.js';
@@ -75,30 +74,49 @@ function initViewer(data) {
     // --- Top-down panel (orthographic) ---
     const topDown = buildPanel('topdown-content', 'orthographic', false);
 
-    // --- Camera trail in top-down panel ---
-    let cameraTrail = null;
-    const trailData = getCameraTrail(data);
+    // --- Camera trail on top-down panel (scaled to pixel space) ---
+    const trailData = hasCamera ? getCameraTrail(data) : null;
+    let topDownTrail = null;
+    let cloudTrail = null;
+
     if (trailData && trailData.length > 0) {
-      cameraTrail = new CameraTrail(topDown.bundle.scene, metadata.width, metadata.height);
-      cameraTrail.setTrail(trailData);
-      disposables.push(cameraTrail);
+      // Scale ego-motion meters to pixel space for top-down view
+      // Trail spans ~15m, scene spans ~1280px → scale ~40
+      const sceneSize = Math.max(metadata.width, metadata.height);
+      const trailSpan = Math.max(
+        ...trailData.map(p => Math.abs(p.position[0])),
+        ...trailData.map(p => Math.abs(p.position[2])),
+        1
+      );
+      const topDownScale = (sceneSize * 0.3) / trailSpan;
+      topDownTrail = new CameraTrail(topDown.bundle.scene, { scale: topDownScale, arrowSize: 20 });
+      topDownTrail.setTrail(trailData);
+      disposables.push(topDownTrail);
     }
 
-    // --- 3D Depth panel (perspective, only if camera data) ---
-    let depth = null;
-    let cameraRenderer = null;
+    // --- 3D Point Cloud panel (bare scene — no floor/zones/objects) ---
+    let cloudBundle = null;
     let pointCloudRenderer = null;
 
     if (hasCamera) {
-      depth = buildPanel('depth-content', 'perspective', true);
-      cameraRenderer = new CameraRenderer(depth.bundle.scene);
-      cameraRenderer.renderCamera(metadata.camera);
-      disposables.push(cameraRenderer);
+      const cloudContainer = document.getElementById('depth-content');
+      cloudBundle = createSceneBundle(
+        cloudContainer, metadata.width, metadata.height, signal, { mode: 'pointcloud' }
+      );
+      disposables.push(cloudBundle.renderer, cloudBundle.labelRenderer);
+
+      // Camera trail on point cloud panel (same scale as points)
+      if (trailData && trailData.length > 0) {
+        // Scale will be set after point cloud loads; use scene-based estimate
+        const pcScale = Math.min(metadata.width, metadata.height) * 0.35 / 15; // rough
+        cloudTrail = new CameraTrail(cloudBundle.scene, { scale: pcScale, arrowSize: 6 });
+        cloudTrail.setTrail(trailData);
+        disposables.push(cloudTrail);
+      }
 
       // Point cloud renderer
-      pointCloudRenderer = new PointCloudRenderer(depth.bundle.scene);
+      pointCloudRenderer = new PointCloudRenderer(cloudBundle.scene, metadata.width, metadata.height);
       disposables.push(pointCloudRenderer);
-      // Load point cloud binary (async, non-blocking)
       probeVideoUrl('point_clouds.bin').then(url => {
         if (url && !signal.aborted && pointCloudRenderer) {
           pointCloudRenderer.loadBinary(url).catch(err => {
@@ -137,16 +155,12 @@ function initViewer(data) {
       topDown.objectRenderer.updateObjects(frameData ? frameData.objects : null);
       topDown.zoneRenderer.updateFromFrame(frameData);
 
-      // Camera trail (uses key index, not raw frame_idx)
-      if (cameraTrail) {
-        cameraTrail.updateFrame(timeline ? timeline.currentKeyIndex : 0);
-      }
+      // Camera trails (uses key index, not raw frame_idx)
+      const keyIdx = timeline ? timeline.currentKeyIndex : 0;
+      if (topDownTrail) topDownTrail.updateFrame(keyIdx);
+      if (cloudTrail) cloudTrail.updateFrame(keyIdx);
 
-      // 3D Depth panel
-      if (depth) {
-        depth.objectRenderer.updateObjects(frameData ? frameData.objects : null);
-        depth.zoneRenderer.updateFromFrame(frameData);
-      }
+      // (Point cloud panel has no objects/zones — cloud updated below)
 
       // Point cloud
       if (pointCloudRenderer) {
@@ -198,7 +212,7 @@ function initViewer(data) {
     timeline.seekToKeyIndex(0);
 
     // --- Render loop — single RAF for all bundles ---
-    const bundles = [topDown.bundle, depth?.bundle].filter(Boolean);
+    const bundles = [topDown.bundle, cloudBundle].filter(Boolean);
     stopLoop = startRenderLoop(bundles);
 
     // --- Auto-load video ---

--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -8,6 +8,7 @@ import { ZoneRenderer } from './zone-renderer.js';
 import { ObjectRenderer } from './object-renderer.js';
 import { CameraTrail } from './camera-trail.js';
 import { PointCloudRenderer } from './point-cloud-renderer.js';
+import { GaussianSplatRenderer } from './gaussian-splat-renderer.js';
 import { Timeline } from './timeline.js';
 import { VideoPanel } from './video-panel.js';
 
@@ -39,7 +40,7 @@ function cleanup() {
   }
 }
 
-function initViewer(data) {
+async function initViewer(data) {
   cleanup();
   abortController = new AbortController();
   const signal = abortController.signal;
@@ -94,36 +95,57 @@ function initViewer(data) {
       disposables.push(topDownTrail);
     }
 
-    // --- 3D Point Cloud panel (bare scene — no floor/zones/objects) ---
+    // --- 3D Gaussian Splat / Point Cloud panel (bare scene — no floor/zones/objects) ---
     let cloudBundle = null;
     let pointCloudRenderer = null;
+    let gaussianRenderer = null;
 
     if (hasCamera) {
       const cloudContainer = document.getElementById('depth-content');
+
+      // Try gaussian splat first, fall back to point cloud
+      const gaussianUrl = await probeVideoUrl('gaussian_splat.ply').catch(() => null);
+      const sceneMode = gaussianUrl ? 'gaussian' : 'pointcloud';
+
       cloudBundle = createSceneBundle(
-        cloudContainer, metadata.width, metadata.height, signal, { mode: 'pointcloud' }
+        cloudContainer, metadata.width, metadata.height, signal, { mode: sceneMode }
       );
       disposables.push(cloudBundle.renderer, cloudBundle.labelRenderer);
 
-      // Camera trail on point cloud panel (same scale as points)
+      // Camera trail on center panel
       if (trailData && trailData.length > 0) {
-        // Scale will be set after point cloud loads; use scene-based estimate
-        const pcScale = Math.min(metadata.width, metadata.height) * 0.35 / 15; // rough
-        cloudTrail = new CameraTrail(cloudBundle.scene, { scale: pcScale, arrowSize: 6 });
+        const pcScale = gaussianUrl
+          ? 1  // COLMAP coordinates are ~metric, no scaling needed
+          : Math.min(metadata.width, metadata.height) * 0.35 / 15;
+        const arrowSize = gaussianUrl ? 0.3 : 6;
+        cloudTrail = new CameraTrail(cloudBundle.scene, { scale: pcScale, arrowSize });
         cloudTrail.setTrail(trailData);
         disposables.push(cloudTrail);
       }
 
-      // Point cloud renderer
-      pointCloudRenderer = new PointCloudRenderer(cloudBundle.scene, metadata.width, metadata.height);
-      disposables.push(pointCloudRenderer);
-      probeVideoUrl('point_clouds.bin').then(url => {
-        if (url && !signal.aborted && pointCloudRenderer) {
-          pointCloudRenderer.loadBinary(url).catch(err => {
-            console.warn('Point cloud load failed:', err.message);
-          });
-        }
-      }).catch(() => {});
+      if (gaussianUrl && !signal.aborted) {
+        // Gaussian splat renderer
+        gaussianRenderer = new GaussianSplatRenderer(cloudBundle.scene);
+        disposables.push(gaussianRenderer);
+        gaussianRenderer.load(gaussianUrl).catch(err => {
+          console.warn('Gaussian splat load failed, falling back to point cloud:', err.message);
+          _loadPointCloudFallback();
+        });
+      } else {
+        _loadPointCloudFallback();
+      }
+
+      function _loadPointCloudFallback() {
+        pointCloudRenderer = new PointCloudRenderer(cloudBundle.scene, metadata.width, metadata.height);
+        disposables.push(pointCloudRenderer);
+        probeVideoUrl('point_clouds.bin').then(url => {
+          if (url && !signal.aborted && pointCloudRenderer) {
+            pointCloudRenderer.loadBinary(url).catch(err => {
+              console.warn('Point cloud load failed:', err.message);
+            });
+          }
+        }).catch(() => {});
+      }
     }
 
     // --- UI elements ---

--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -104,47 +104,60 @@ async function initViewer(data) {
       const cloudContainer = document.getElementById('depth-content');
 
       // Try gaussian splat first, fall back to point cloud
-      const gaussianUrl = await probeVideoUrl('gaussian_splat.ply').catch(() => null);
-      const sceneMode = gaussianUrl ? 'gaussian' : 'pointcloud';
+      const gaussianUrl = await probeVideoUrl('gaussian_splat.ply');
 
-      cloudBundle = createSceneBundle(
-        cloudContainer, metadata.width, metadata.height, signal, { mode: sceneMode }
-      );
-      disposables.push(cloudBundle.renderer, cloudBundle.labelRenderer);
+      function setupCloudPanel(mode) {
+        // Tear down previous bundle if rebuilding on fallback
+        if (cloudBundle) {
+          cloudBundle.renderer.dispose();
+          cloudBundle.renderer.domElement.remove();
+          cloudBundle.labelRenderer.domElement.remove();
+          if (cloudTrail) { cloudTrail.dispose(); cloudTrail = null; }
+          cloudContainer.replaceChildren();
+        }
+        cloudBundle = createSceneBundle(
+          cloudContainer, metadata.width, metadata.height, signal, { mode }
+        );
+        disposables.push(cloudBundle.renderer, cloudBundle.labelRenderer);
 
-      // Camera trail on center panel
-      if (trailData && trailData.length > 0) {
-        const pcScale = gaussianUrl
-          ? 1  // COLMAP coordinates are ~metric, no scaling needed
-          : Math.min(metadata.width, metadata.height) * 0.35 / 15;
-        const arrowSize = gaussianUrl ? 0.3 : 6;
-        cloudTrail = new CameraTrail(cloudBundle.scene, { scale: pcScale, arrowSize });
-        cloudTrail.setTrail(trailData);
-        disposables.push(cloudTrail);
+        // Camera trail
+        if (trailData && trailData.length > 0) {
+          const trailConfig = mode === 'gaussian'
+            ? { scale: 1, arrowSize: 0.3 }
+            : { scale: Math.min(metadata.width, metadata.height) * 0.35 / 15, arrowSize: 6 };
+          cloudTrail = new CameraTrail(cloudBundle.scene, trailConfig);
+          cloudTrail.setTrail(trailData);
+          disposables.push(cloudTrail);
+        }
+        return cloudBundle;
       }
 
-      if (gaussianUrl && !signal.aborted) {
-        // Gaussian splat renderer
-        gaussianRenderer = new GaussianSplatRenderer(cloudBundle.scene);
-        disposables.push(gaussianRenderer);
-        gaussianRenderer.load(gaussianUrl).catch(err => {
-          console.warn('Gaussian splat load failed, falling back to point cloud:', err.message);
-          _loadPointCloudFallback();
-        });
-      } else {
-        _loadPointCloudFallback();
-      }
-
-      function _loadPointCloudFallback() {
+      function loadPointCloud() {
+        setupCloudPanel('pointcloud');
         pointCloudRenderer = new PointCloudRenderer(cloudBundle.scene, metadata.width, metadata.height);
         disposables.push(pointCloudRenderer);
         probeVideoUrl('point_clouds.bin').then(url => {
           if (url && !signal.aborted && pointCloudRenderer) {
             pointCloudRenderer.loadBinary(url).catch(err => {
-              console.warn('Point cloud load failed:', err.message);
+              console.warn('[PointCloud] Load failed:', err.message);
             });
           }
-        }).catch(() => {});
+        }).catch(err => {
+          console.warn('[PointCloud] Probe failed:', err.message);
+        });
+      }
+
+      if (gaussianUrl && !signal.aborted) {
+        setupCloudPanel('gaussian');
+        gaussianRenderer = new GaussianSplatRenderer(cloudBundle.scene);
+        disposables.push(gaussianRenderer);
+        gaussianRenderer.load(gaussianUrl).catch(err => {
+          console.warn('[GaussianSplat] Load failed, falling back to point cloud:', err.message);
+          gaussianRenderer.dispose();
+          loadPointCloud();
+        });
+      } else {
+        loadPointCloud();
       }
     }
 
@@ -240,7 +253,9 @@ async function initViewer(data) {
     // --- Auto-load video ---
     probeVideoUrl('spatial_annotated.mp4').then(url => {
       if (url && !signal.aborted && videoPanel) videoPanel.loadVideo(url);
-    }).catch(() => {});
+    }).catch(err => {
+      console.warn('[Video] Auto-load failed:', err.message);
+    });
 
   } catch (err) {
     console.error('Failed to initialize viewer:', err);

--- a/viewer/js/camera-trail.js
+++ b/viewer/js/camera-trail.js
@@ -1,22 +1,27 @@
 /**
- * Camera trail renderer for the top-down panel.
+ * Camera trail renderer.
  * Shows a polyline of the camera path and an arrow at the current position.
  */
 import * as THREE from 'three';
 
 const TRAIL_COLOR = 0xfbbf24; // amber
 const ARROW_COLOR = 0xf97316; // orange
-const ARROW_SIZE = 8;
 
 export class CameraTrail {
-  constructor(scene, sceneWidth, sceneHeight) {
+  /**
+   * @param {THREE.Scene} scene
+   * @param {object} options
+   * @param {number} [options.scale=1] - Multiply ego-motion positions by this factor.
+   * @param {number} [options.arrowSize=8] - Size of the position arrow cone.
+   */
+  constructor(scene, { scale = 1, arrowSize = 8 } = {}) {
     this.scene = scene;
-    this.sceneWidth = sceneWidth;
-    this.sceneHeight = sceneHeight;
+    this.scale = scale;
+    this.arrowSize = arrowSize;
     this.poses = [];
     this.trailLine = null;
     this.arrow = null;
-    this._positions = []; // THREE.Vector3 array
+    this._positions = [];
   }
 
   /**
@@ -27,13 +32,15 @@ export class CameraTrail {
     if (!poses || poses.length === 0) return;
     this.poses = poses;
 
-    // Convert to Three.js coordinates (Y-up: x, z, -y)
+    const s = this.scale;
+    // Ego-motion positions: [x_lateral, 0, z_forward]
+    // Three.js Y-up: X = world X, Y = elevation, Z = -world Z
     this._positions = poses.map(p => {
-      const [x, y, z] = p.position;
-      return new THREE.Vector3(x, z, -y);
+      const [x, _y, z] = p.position;
+      return new THREE.Vector3(x * s, 1, -z * s);
     });
 
-    // Create the full trail line (initially invisible segments revealed per frame)
+    // Trail polyline
     const geometry = new THREE.BufferGeometry().setFromPoints(this._positions);
     const material = new THREE.LineBasicMaterial({
       color: TRAIL_COLOR,
@@ -42,36 +49,29 @@ export class CameraTrail {
       opacity: 0.8,
     });
     this.trailLine = new THREE.Line(geometry, material);
-    // Start with full line hidden; updateFrame reveals segments
     this.trailLine.geometry.setDrawRange(0, 0);
     this.scene.add(this.trailLine);
 
     // Arrow cone at current position
-    const coneGeom = new THREE.ConeGeometry(ARROW_SIZE * 0.6, ARROW_SIZE, 8);
+    const as = this.arrowSize;
+    const coneGeom = new THREE.ConeGeometry(as * 0.6, as, 8);
     const coneMat = new THREE.MeshStandardMaterial({ color: ARROW_COLOR });
     this.arrow = new THREE.Mesh(coneGeom, coneMat);
     this.arrow.position.copy(this._positions[0]);
-    this.arrow.position.y += ARROW_SIZE;
+    this.arrow.position.y += as;
     this.scene.add(this.arrow);
   }
 
-  /**
-   * Update trail visibility up to frameIdx and move arrow.
-   */
   updateFrame(frameIdx) {
     if (!this._positions.length) return;
-
     const idx = Math.min(frameIdx, this._positions.length - 1);
 
-    // Reveal trail up to current frame
     if (this.trailLine) {
       this.trailLine.geometry.setDrawRange(0, idx + 1);
     }
-
-    // Move arrow to current position
     if (this.arrow && this._positions[idx]) {
       this.arrow.position.copy(this._positions[idx]);
-      this.arrow.position.y += ARROW_SIZE;
+      this.arrow.position.y += this.arrowSize;
     }
   }
 

--- a/viewer/js/data-loader.js
+++ b/viewer/js/data-loader.js
@@ -56,6 +56,11 @@ export async function probeVideoUrl(url) {
   try {
     const resp = await fetch(url, { method: 'HEAD' });
     if (resp.ok) return url;
-  } catch { /* ignore */ }
+    if (resp.status !== 404) {
+      console.warn(`[Probe] ${url} returned HTTP ${resp.status}`);
+    }
+  } catch (err) {
+    console.warn(`[Probe] ${url} failed:`, err.message);
+  }
   return null;
 }

--- a/viewer/js/gaussian-splat-renderer.js
+++ b/viewer/js/gaussian-splat-renderer.js
@@ -11,6 +11,8 @@ export class GaussianSplatRenderer {
     this.scene = scene;
     this.splat = null;
     this._loaded = false;
+    this._disposed = false;
+    this._timeoutId = null;
   }
 
   /**
@@ -22,8 +24,8 @@ export class GaussianSplatRenderer {
   load(url) {
     console.log('[GaussianSplat] Loading:', url);
     return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        if (!this._loaded) {
+      this._timeoutId = setTimeout(() => {
+        if (!this._loaded && !this._disposed) {
           reject(new Error(`Gaussian splat load timed out after ${LOAD_TIMEOUT_MS / 1000}s`));
         }
       }, LOAD_TIMEOUT_MS);
@@ -32,15 +34,26 @@ export class GaussianSplatRenderer {
         this.splat = new SplatMesh({
           url,
           onLoad: () => {
-            clearTimeout(timeout);
+            clearTimeout(this._timeoutId);
+            this._timeoutId = null;
+            if (this._disposed) return;
             this._loaded = true;
             console.log('[GaussianSplat] Loaded successfully');
             resolve();
           },
+          // Spark may support onError for async load failures (network, parse).
+          // If not recognized, it is silently ignored and the timeout acts as fallback.
+          onError: (err) => {
+            clearTimeout(this._timeoutId);
+            this._timeoutId = null;
+            if (this._disposed) return;
+            reject(err instanceof Error ? err : new Error(String(err)));
+          },
         });
         this.scene.add(this.splat);
       } catch (err) {
-        clearTimeout(timeout);
+        clearTimeout(this._timeoutId);
+        this._timeoutId = null;
         reject(err);
       }
     });
@@ -51,6 +64,11 @@ export class GaussianSplatRenderer {
   }
 
   dispose() {
+    this._disposed = true;
+    if (this._timeoutId) {
+      clearTimeout(this._timeoutId);
+      this._timeoutId = null;
+    }
     if (this.splat) {
       try {
         this.scene.remove(this.splat);

--- a/viewer/js/gaussian-splat-renderer.js
+++ b/viewer/js/gaussian-splat-renderer.js
@@ -1,0 +1,45 @@
+/**
+ * Gaussian Splatting renderer using Spark (sparkjs.dev).
+ * Wraps SplatMesh for Three.js integration in the DINO Spatial Viewer.
+ */
+import { SplatMesh } from '@sparkjsdev/spark';
+
+export class GaussianSplatRenderer {
+  constructor(scene) {
+    this.scene = scene;
+    this.splat = null;
+    this._loaded = false;
+  }
+
+  /**
+   * Load a gaussian splat from a URL (.ply, .splat, .spz).
+   * @param {string} url
+   * @returns {Promise<void>}
+   */
+  async load(url) {
+    console.log('[GaussianSplat] Loading:', url);
+    this.splat = new SplatMesh({
+      url,
+      onLoad: () => {
+        this._loaded = true;
+        console.log('[GaussianSplat] Loaded successfully');
+      },
+    });
+    this.scene.add(this.splat);
+  }
+
+  get loaded() {
+    return this._loaded;
+  }
+
+  dispose() {
+    if (this.splat) {
+      this.scene.remove(this.splat);
+      if (typeof this.splat.dispose === 'function') {
+        this.splat.dispose();
+      }
+      this.splat = null;
+    }
+    this._loaded = false;
+  }
+}

--- a/viewer/js/gaussian-splat-renderer.js
+++ b/viewer/js/gaussian-splat-renderer.js
@@ -4,6 +4,8 @@
  */
 import { SplatMesh } from '@sparkjsdev/spark';
 
+const LOAD_TIMEOUT_MS = 60_000;
+
 export class GaussianSplatRenderer {
   constructor(scene) {
     this.scene = scene;
@@ -13,19 +15,35 @@ export class GaussianSplatRenderer {
 
   /**
    * Load a gaussian splat from a URL (.ply, .splat, .spz).
+   * Resolves when loading completes, rejects on error or timeout.
    * @param {string} url
    * @returns {Promise<void>}
    */
-  async load(url) {
+  load(url) {
     console.log('[GaussianSplat] Loading:', url);
-    this.splat = new SplatMesh({
-      url,
-      onLoad: () => {
-        this._loaded = true;
-        console.log('[GaussianSplat] Loaded successfully');
-      },
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        if (!this._loaded) {
+          reject(new Error(`Gaussian splat load timed out after ${LOAD_TIMEOUT_MS / 1000}s`));
+        }
+      }, LOAD_TIMEOUT_MS);
+
+      try {
+        this.splat = new SplatMesh({
+          url,
+          onLoad: () => {
+            clearTimeout(timeout);
+            this._loaded = true;
+            console.log('[GaussianSplat] Loaded successfully');
+            resolve();
+          },
+        });
+        this.scene.add(this.splat);
+      } catch (err) {
+        clearTimeout(timeout);
+        reject(err);
+      }
     });
-    this.scene.add(this.splat);
   }
 
   get loaded() {
@@ -34,9 +52,13 @@ export class GaussianSplatRenderer {
 
   dispose() {
     if (this.splat) {
-      this.scene.remove(this.splat);
-      if (typeof this.splat.dispose === 'function') {
-        this.splat.dispose();
+      try {
+        this.scene.remove(this.splat);
+        if (typeof this.splat.dispose === 'function') {
+          this.splat.dispose();
+        }
+      } catch (err) {
+        console.warn('[GaussianSplat] Dispose error:', err.message);
       }
       this.splat = null;
     }

--- a/viewer/js/point-cloud-renderer.js
+++ b/viewer/js/point-cloud-renderer.js
@@ -1,31 +1,38 @@
 /**
  * Point cloud renderer for the 3D depth panel.
- * Loads binary .bin files and renders per-frame point clouds using THREE.Points.
+ * Loads binary .bin files and renders accumulated per-frame point clouds.
  */
 import * as THREE from 'three';
 
 const POINT_COLOR = 0x38bdf8; // sky-400
-const POINT_SIZE = 2;
+const POINT_SIZE = 3;
+const ACCUMULATE_FRAMES = 60; // keep last N frames for dense reconstruction
 
 export class PointCloudRenderer {
-  constructor(scene) {
+  constructor(scene, sceneWidth, sceneHeight) {
     this.scene = scene;
-    this.buffer = null;       // ArrayBuffer
+    this.sceneWidth = sceneWidth || 720;
+    this.sceneHeight = sceneHeight || 1280;
+    this.buffer = null;
     this.numFrames = 0;
-    this.frameIndex = [];     // [{offset, numPoints}, ...]
-    this.points = null;       // THREE.Points
+    this.frameIndex = [];
+    this.points = null;
     this._geometry = null;
     this._material = null;
+    this._scaleFactor = 0;
+    this._frameCache = new Map(); // frameIdx -> Float32Array (scaled)
+    this._lastIdx = -1;
   }
 
-  /**
-   * Fetch and parse the binary point cloud file.
-   */
   async loadBinary(url) {
+    console.log('[PointCloud] Fetching:', url);
     const resp = await fetch(url);
     if (!resp.ok) throw new Error(`Failed to load point cloud: ${resp.status}`);
     this.buffer = await resp.arrayBuffer();
+    console.log('[PointCloud] Loaded:', (this.buffer.byteLength / 1024 / 1024).toFixed(1), 'MB');
     this._parseIndex();
+    console.log('[PointCloud] Frames:', this.numFrames);
+    this._computeScale();
     this._initPoints();
   }
 
@@ -33,15 +40,36 @@ export class PointCloudRenderer {
     const view = new DataView(this.buffer);
     this.numFrames = view.getUint32(0, true);
     const indexOffset = view.getUint32(4, true);
-
     this.frameIndex = [];
     for (let i = 0; i < this.numFrames; i++) {
-      const entryOffset = indexOffset + i * 12; // uint64 (8) + uint32 (4)
-      // Read uint64 as two uint32s (assume < 4GB)
+      const entryOffset = indexOffset + i * 12;
       const offsetLow = view.getUint32(entryOffset, true);
       const numPoints = view.getUint32(entryOffset + 8, true);
       this.frameIndex.push({ offset: offsetLow, numPoints });
     }
+  }
+
+  _computeScale() {
+    // Sample a few frames to determine extent
+    const sampled = [0, Math.floor(this.numFrames / 2), this.numFrames - 1];
+    let minX = Infinity, maxX = -Infinity;
+    let minY = Infinity, maxY = -Infinity;
+    let minZ = Infinity, maxZ = -Infinity;
+    for (const fi of sampled) {
+      const entry = this.frameIndex[fi];
+      if (!entry || entry.numPoints === 0) continue;
+      const dataOffset = entry.offset + 4;
+      const fa = new Float32Array(this.buffer, dataOffset, entry.numPoints * 3);
+      for (let i = 0; i < entry.numPoints; i++) {
+        const b = i * 3;
+        if (fa[b] < minX) minX = fa[b]; if (fa[b] > maxX) maxX = fa[b];
+        if (fa[b+1] < minY) minY = fa[b+1]; if (fa[b+1] > maxY) maxY = fa[b+1];
+        if (fa[b+2] < minZ) minZ = fa[b+2]; if (fa[b+2] > maxZ) maxZ = fa[b+2];
+      }
+    }
+    const span = Math.max(maxX - minX, maxY - minY, maxZ - minZ, 0.01);
+    this._scaleFactor = Math.min(this.sceneWidth, this.sceneHeight) * 0.35 / span;
+    console.log('[PointCloud] Full extent:', span.toFixed(2), 'scale:', this._scaleFactor.toFixed(1));
   }
 
   _initPoints() {
@@ -52,7 +80,6 @@ export class PointCloudRenderer {
       transparent: true,
       opacity: 0.7,
     });
-    // Start with empty geometry
     this._geometry = new THREE.BufferGeometry();
     this._geometry.setAttribute(
       'position',
@@ -63,52 +90,83 @@ export class PointCloudRenderer {
   }
 
   /**
-   * Update point cloud to show data for the given frame index.
+   * Read and scale a single frame's points (cached).
+   */
+  _getFramePoints(idx) {
+    if (this._frameCache.has(idx)) return this._frameCache.get(idx);
+    const entry = this.frameIndex[idx];
+    if (!entry || entry.numPoints === 0) return null;
+
+    const dataOffset = entry.offset + 4;
+    const raw = new Float32Array(this.buffer, dataOffset, entry.numPoints * 3);
+    const s = this._scaleFactor || 1;
+    const out = new Float32Array(entry.numPoints * 3);
+    for (let i = 0; i < entry.numPoints; i++) {
+      const b = i * 3;
+      out[b] = raw[b] * s;           // x
+      out[b + 1] = raw[b + 2] * s;   // z -> y (up)
+      out[b + 2] = -raw[b + 1] * s;  // -y -> z
+    }
+
+    // Evict old cache entries
+    if (this._frameCache.size > ACCUMULATE_FRAMES + 10) {
+      const oldest = this._frameCache.keys().next().value;
+      this._frameCache.delete(oldest);
+    }
+    this._frameCache.set(idx, out);
+    return out;
+  }
+
+  /**
+   * Update point cloud — accumulate last N frames for dense reconstruction.
    */
   updateFrame(frameIdx) {
     if (!this.buffer || !this.frameIndex.length || !this._geometry) return;
-
     const idx = Math.min(frameIdx, this.frameIndex.length - 1);
-    const entry = this.frameIndex[idx];
-    if (!entry || entry.numPoints === 0) {
+    if (idx === this._lastIdx) return;
+    this._lastIdx = idx;
+
+    // Gather points from last ACCUMULATE_FRAMES frames
+    const startIdx = Math.max(0, idx - ACCUMULATE_FRAMES + 1);
+    const arrays = [];
+    let totalPoints = 0;
+    for (let f = startIdx; f <= idx; f++) {
+      const pts = this._getFramePoints(f);
+      if (pts) {
+        arrays.push(pts);
+        totalPoints += pts.length / 3;
+      }
+    }
+
+    if (totalPoints === 0) {
       this._geometry.setAttribute(
-        'position',
-        new THREE.BufferAttribute(new Float32Array(0), 3)
+        'position', new THREE.BufferAttribute(new Float32Array(0), 3)
       );
       this._geometry.attributes.position.needsUpdate = true;
       return;
     }
 
-    // Read point data: skip uint32 num_points header, then float32[n*3]
-    const dataOffset = entry.offset + 4; // skip num_points uint32
-    const floatArray = new Float32Array(
-      this.buffer, dataOffset, entry.numPoints * 3
-    );
-
-    // Apply Y-up coordinate swap: [x, z, -y]
-    const swapped = new Float32Array(entry.numPoints * 3);
-    for (let i = 0; i < entry.numPoints; i++) {
-      const base = i * 3;
-      swapped[base] = floatArray[base];        // x
-      swapped[base + 1] = floatArray[base + 2]; // z -> y (up)
-      swapped[base + 2] = -floatArray[base + 1]; // -y -> z
+    // Merge all frame arrays
+    const merged = new Float32Array(totalPoints * 3);
+    let offset = 0;
+    for (const arr of arrays) {
+      merged.set(arr, offset);
+      offset += arr.length;
     }
 
     this._geometry.setAttribute(
-      'position',
-      new THREE.BufferAttribute(swapped, 3)
+      'position', new THREE.BufferAttribute(merged, 3)
     );
     this._geometry.attributes.position.needsUpdate = true;
     this._geometry.computeBoundingSphere();
   }
 
   dispose() {
-    if (this.points) {
-      this.scene.remove(this.points);
-    }
+    if (this.points) this.scene.remove(this.points);
     if (this._geometry) this._geometry.dispose();
     if (this._material) this._material.dispose();
     this.buffer = null;
     this.frameIndex = [];
+    this._frameCache.clear();
   }
 }

--- a/viewer/js/scene.js
+++ b/viewer/js/scene.js
@@ -23,7 +23,13 @@ export function createSceneBundle(container, width, height, signal, { mode = 'or
   const aspect = container.clientWidth / (container.clientHeight || 1);
   let camera;
 
-  if (mode === 'perspective') {
+  if (mode === 'pointcloud') {
+    // Tight camera for point cloud — closer view, no floor plan
+    const size = Math.min(width, height) * 0.3;
+    camera = new THREE.PerspectiveCamera(50, aspect, 1, 5000);
+    camera.position.set(0, size * 1.2, size * 1.0);
+    camera.lookAt(0, 0, 0);
+  } else if (mode === 'perspective') {
     camera = new THREE.PerspectiveCamera(60, aspect, 1, 5000);
     camera.position.set(0, Math.max(width, height) * 0.8, Math.max(width, height) * 0.6);
     camera.lookAt(0, 0, 0);
@@ -61,7 +67,7 @@ export function createSceneBundle(container, width, height, signal, { mode = 'or
     controls.enableRotate = false; // top-down: pan + zoom only
   } else {
     controls.enableRotate = true;
-    controls.maxPolarAngle = Math.PI / 2;
+    controls.maxPolarAngle = (mode === 'pointcloud') ? Math.PI : Math.PI / 2;
   }
 
   // Lights

--- a/viewer/js/scene.js
+++ b/viewer/js/scene.js
@@ -72,7 +72,7 @@ export function createSceneBundle(container, width, height, signal, { mode = 'or
     controls.enableRotate = false; // top-down: pan + zoom only
   } else {
     controls.enableRotate = true;
-    controls.maxPolarAngle = (mode === 'pointcloud' || mode === 'gaussian') ? Math.PI : Math.PI / 2;
+    controls.maxPolarAngle = mode === 'perspective' ? Math.PI / 2 : Math.PI;
   }
 
   // Lights

--- a/viewer/js/scene.js
+++ b/viewer/js/scene.js
@@ -23,7 +23,12 @@ export function createSceneBundle(container, width, height, signal, { mode = 'or
   const aspect = container.clientWidth / (container.clientHeight || 1);
   let camera;
 
-  if (mode === 'pointcloud') {
+  if (mode === 'gaussian') {
+    // Gaussian splat — wide FOV, generous near/far for COLMAP-scale scenes
+    camera = new THREE.PerspectiveCamera(60, aspect, 0.1, 1000);
+    camera.position.set(0, 5, 10);
+    camera.lookAt(0, 0, 0);
+  } else if (mode === 'pointcloud') {
     // Tight camera for point cloud — closer view, no floor plan
     const size = Math.min(width, height) * 0.3;
     camera = new THREE.PerspectiveCamera(50, aspect, 1, 5000);
@@ -67,7 +72,7 @@ export function createSceneBundle(container, width, height, signal, { mode = 'or
     controls.enableRotate = false; // top-down: pan + zoom only
   } else {
     controls.enableRotate = true;
-    controls.maxPolarAngle = (mode === 'pointcloud') ? Math.PI : Math.PI / 2;
+    controls.maxPolarAngle = (mode === 'pointcloud' || mode === 'gaussian') ? Math.PI : Math.PI / 2;
   }
 
   // Lights

--- a/viewer/js/scene.js
+++ b/viewer/js/scene.js
@@ -24,10 +24,11 @@ export function createSceneBundle(container, width, height, signal, { mode = 'or
   let camera;
 
   if (mode === 'gaussian') {
-    // Gaussian splat — wide FOV, generous near/far for COLMAP-scale scenes
+    // Gaussian splat — COLMAP coordinate system
+    // Scene: X [-9,7], Y [-6,4], Z [-3,13], center ~(0, -1, 4)
     camera = new THREE.PerspectiveCamera(60, aspect, 0.1, 1000);
-    camera.position.set(0, 5, 10);
-    camera.lookAt(0, 0, 0);
+    camera.position.set(0, -1, -3);
+    camera.lookAt(0, -1, 5);
   } else if (mode === 'pointcloud') {
     // Tight camera for point cloud — closer view, no floor plan
     const size = Math.min(width, height) * 0.3;
@@ -68,6 +69,9 @@ export function createSceneBundle(container, width, height, signal, { mode = 'or
   const controls = new OrbitControls(camera, renderer.domElement);
   controls.enablePan = true;
   controls.enableZoom = true;
+  if (mode === 'gaussian') {
+    controls.target.set(0, -1, 5);
+  }
   if (mode === 'orthographic') {
     controls.enableRotate = false; // top-down: pan + zoom only
   } else {

--- a/viewer/js/video-panel.js
+++ b/viewer/js/video-panel.js
@@ -8,6 +8,7 @@ export class VideoPanel {
     this.metadata = metadata;
     this.video = null;
     this.blobUrl = null;
+    this._isPlaying = false;
 
     this._buildDOM();
   }
@@ -22,6 +23,7 @@ export class VideoPanel {
     this.video.className = 'video-element';
     this.video.muted = true;
     this.video.playsInline = true;
+    this.video.loop = true;
     this.container.appendChild(this.video);
   }
 
@@ -54,9 +56,14 @@ export class VideoPanel {
    * Seek the video to match the given frame index.
    */
   seekToFrame(frameIdx, _frameData) {
+    const prevIdx = this._lastFrameIdx;
+    this._lastFrameIdx = frameIdx;
     if (!this.video.src) return;
     const fps = this.metadata.fps * (this.metadata.stride || 1);
-    this.video.currentTime = frameIdx / fps;
+    // Always seek on loop wrap (frameIdx jumped backwards) or when paused
+    if (!this._isPlaying || (prevIdx != null && frameIdx < prevIdx)) {
+      this.video.currentTime = frameIdx / fps;
+    }
   }
 
   /**
@@ -65,9 +72,15 @@ export class VideoPanel {
    * @param {number} speed - Playback speed multiplier.
    */
   setPlaying(isPlaying, speed) {
+    this._isPlaying = isPlaying;
     if (!this.video.src) return;
     this.video.playbackRate = speed;
     if (isPlaying) {
+      // Sync position before starting playback
+      const fps = this.metadata.fps * (this.metadata.stride || 1);
+      if (this._lastFrameIdx != null) {
+        this.video.currentTime = this._lastFrameIdx / fps;
+      }
       this.video.play().catch(() => {});
     } else {
       this.video.pause();

--- a/viewer/serve.py
+++ b/viewer/serve.py
@@ -1,8 +1,69 @@
 #!/usr/bin/env python3
-"""Simple HTTP server for the DINO 3D Spatial Viewer."""
+"""Simple HTTP server for the DINO 3D Spatial Viewer.
+
+Adds gzip Content-Encoding for large files (.ply) and proper MIME types.
+"""
 import argparse
+import gzip
 import http.server
 import functools
+import os
+
+# Files above this threshold get gzip-compressed on the fly
+GZIP_THRESHOLD = 10 * 1024 * 1024  # 10 MB
+
+EXTRA_MIME_TYPES = {
+    ".ply": "application/octet-stream",
+    ".splat": "application/octet-stream",
+    ".spz": "application/octet-stream",
+}
+
+
+class GzipHandler(http.server.SimpleHTTPRequestHandler):
+    """HTTP handler that serves large files with gzip Content-Encoding."""
+
+    def end_headers(self):
+        self.send_header("Access-Control-Allow-Origin", "*")
+        super().end_headers()
+
+    def do_GET(self):
+        path = self.translate_path(self.path)
+        if not os.path.isfile(path):
+            return super().do_GET()
+
+        size = os.path.getsize(path)
+        accept_gzip = "gzip" in self.headers.get("Accept-Encoding", "")
+
+        if size > GZIP_THRESHOLD and accept_gzip:
+            self._serve_gzipped(path, size)
+        else:
+            super().do_GET()
+
+    def _serve_gzipped(self, path, _original_size):
+        ext = os.path.splitext(path)[1].lower()
+        content_type = EXTRA_MIME_TYPES.get(ext) or self.guess_type(path)
+
+        try:
+            with open(path, "rb") as f:
+                raw = f.read()
+        except OSError:
+            self.send_error(404, "File not found")
+            return
+
+        compressed = gzip.compress(raw, compresslevel=6)
+
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Encoding", "gzip")
+        self.send_header("Content-Length", str(len(compressed)))
+        self.end_headers()
+        self.wfile.write(compressed)
+
+    def guess_type(self, path):
+        ext = os.path.splitext(path)[1].lower()
+        if ext in EXTRA_MIME_TYPES:
+            return EXTRA_MIME_TYPES[ext]
+        return super().guess_type(path)
 
 
 def main():
@@ -10,7 +71,7 @@ def main():
     parser.add_argument("--port", type=int, default=8080)
     args = parser.parse_args()
 
-    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=".")
+    handler = functools.partial(GzipHandler, directory=".")
     with http.server.HTTPServer(("127.0.0.1", args.port), handler) as httpd:
         print(f"DINO Viewer serving at http://localhost:{args.port}")
         print("Press Ctrl+C to stop")

--- a/viewer/serve.py
+++ b/viewer/serve.py
@@ -2,6 +2,7 @@
 """Simple HTTP server for the DINO 3D Spatial Viewer.
 
 Adds gzip Content-Encoding for large files (.ply) and proper MIME types.
+Intended for local development only — do not expose to a network.
 """
 import argparse
 import gzip
@@ -35,29 +36,43 @@ class GzipHandler(http.server.SimpleHTTPRequestHandler):
         accept_gzip = "gzip" in self.headers.get("Accept-Encoding", "")
 
         if size > GZIP_THRESHOLD and accept_gzip:
-            self._serve_gzipped(path, size)
+            self._serve_gzipped(path)
         else:
             super().do_GET()
 
-    def _serve_gzipped(self, path, _original_size):
-        ext = os.path.splitext(path)[1].lower()
-        content_type = EXTRA_MIME_TYPES.get(ext) or self.guess_type(path)
+    def _serve_gzipped(self, path):
+        content_type = self.guess_type(path)
 
         try:
             with open(path, "rb") as f:
                 raw = f.read()
-        except OSError:
+        except FileNotFoundError:
             self.send_error(404, "File not found")
             return
+        except PermissionError:
+            self.send_error(403, "Permission denied")
+            return
+        except OSError as e:
+            self.log_error("Error reading %s: %s", path, e)
+            self.send_error(500, "Internal server error")
+            return
 
-        compressed = gzip.compress(raw, compresslevel=6)
+        try:
+            compressed = gzip.compress(raw, compresslevel=6)
+        except (MemoryError, OSError) as e:
+            self.log_error("Gzip compression failed for %s: %s", path, e)
+            self.send_error(500, "Compression failed")
+            return
 
         self.send_response(200)
         self.send_header("Content-Type", content_type)
         self.send_header("Content-Encoding", "gzip")
         self.send_header("Content-Length", str(len(compressed)))
         self.end_headers()
-        self.wfile.write(compressed)
+        try:
+            self.wfile.write(compressed)
+        except (BrokenPipeError, ConnectionResetError):
+            self.log_error("Client disconnected during transfer of %s", path)
 
     def guess_type(self, path):
         ext = os.path.splitext(path)[1].lower()

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -41,7 +41,8 @@ h1 {
   grid-template-columns: 1fr 1fr;
 }
 
-#viewport-strip.two-col #panel-depth {
+#viewport-strip.two-col #panel-depth,
+#viewport-strip.two-col #panel-topdown {
   display: none;
 }
 


### PR DESCRIPTION
## Summary

- Replace sparse monocular depth point cloud with photorealistic Gaussian Splatting rendering using [Spark](https://sparkjs.dev/) (`SplatMesh`)
- Upgrade Three.js 0.162→0.178 for Spark compatibility
- Graceful fallback to `point_clouds.bin` if no `.ply` file is available
- Add gzip compression + CORS to `serve.py` for large file delivery

## Changes

| File | What |
|------|------|
| `viewer/index.html` | Three.js 0.178 + Spark importmap, panel label update |
| `viewer/js/gaussian-splat-renderer.js` | **NEW** — Spark SplatMesh wrapper |
| `viewer/js/app.js` | Probe for gaussian_splat.ply, fallback to point cloud |
| `viewer/js/scene.js` | `'gaussian'` camera mode (wide FOV, full orbit) |
| `viewer/serve.py` | Gzip Content-Encoding for large files, CORS headers |
| `.gitignore` | Exclude large viewer assets and output/ |

## Test plan

- [ ] Load viewer with `gaussian_splat.ply` present — should render photorealistic 3D scene
- [ ] Orbit/zoom/pan around the gaussian splat
- [ ] Remove `.ply` file — should fall back to point cloud rendering
- [ ] Verify video panel and top-down panel still work after Three.js upgrade
- [ ] Camera trail visible overlaid on gaussian scene
- [ ] Check 30+ fps on modern browser

Fixes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)