### PR TITLE
feat: SLAM-style spatial awareness viewer

### DIFF
--- a/src/dino/spatial/depth_cloud_writer.py
+++ b/src/dino/spatial/depth_cloud_writer.py
@@ -12,13 +12,24 @@ from dino.spatial.models import CameraIntrinsics
 
 logger = logging.getLogger(__name__)
 
+# V2 magic number: "DINO" in little-endian
+_V2_MAGIC = 0x44494E4F
+_V2_HEADER_SIZE = 12  # uint32 magic + uint16 version + uint16 flags + uint32 indexOffset
+_LEGACY_HEADER_SIZE = 8  # uint32 num_frames + uint32 index_offset
+
 
 class DepthCloudWriter:
     """Sample depth maps to point clouds and write binary .bin files.
 
-    Binary format:
+    Binary format (V1 legacy, when rgb_frame is never provided):
         Header (8 bytes): uint32 num_frames, uint32 index_offset
         Frame data: [uint32 num_points, float32[num_points*3] xyz] per frame
+        Index (at index_offset): [uint64 byte_offset, uint32 num_points] per frame
+
+    Binary format (V2, when rgb_frame is provided on first call):
+        Header (12 bytes): uint32 magic(0x44494E4F), uint16 version(2),
+                           uint16 flags(bit0=has_rgb), uint32 indexOffset
+        Frame data: [uint32 num_points, float32[N*3] xyz, uint8[N*3] rgb] per frame
         Index (at index_offset): [uint64 byte_offset, uint32 num_points] per frame
     """
 
@@ -35,6 +46,7 @@ class DepthCloudWriter:
         self.grid_step = grid_step
         self.frame_offsets: list[tuple[int, int]] = []
         self._file: BinaryIO | None = None
+        self._v2: bool | None = None  # None = not decided yet
 
     def __enter__(self):
         self.open()
@@ -47,15 +59,28 @@ class DepthCloudWriter:
     def open(self) -> None:
         self.output_path.parent.mkdir(parents=True, exist_ok=True)
         self._file = open(self.output_path, "wb")
-        # Reserve header: num_frames (u32) + index_offset (u32)
-        self._file.write(b"\x00" * 8)
+        # Reserve max header space (12 bytes for V2, 8 for legacy)
+        # We'll decide format on first write_frame call
+        self._file.write(b"\x00" * _V2_HEADER_SIZE)
 
     def write_frame(
-        self, depth_map: np.ndarray, frame_pose: np.ndarray | None = None
+        self,
+        depth_map: np.ndarray,
+        frame_pose: np.ndarray | None = None,
+        rgb_frame: np.ndarray | None = None,
     ) -> None:
-        """Sample grid from HxW depth map, backproject to world, write float32 xyz."""
+        """Sample grid from HxW depth map, backproject to world, write xyz (+ optional rgb)."""
         if self._file is None:
             raise RuntimeError("Writer not opened. Call open() first.")
+
+        # Decide format on first frame
+        if self._v2 is None:
+            self._v2 = rgb_frame is not None
+            if not self._v2:
+                # Legacy mode: rewind to 8-byte header
+                self._file.seek(0)
+                self._file.write(b"\x00" * _LEGACY_HEADER_SIZE)
+                self._file.seek(_LEGACY_HEADER_SIZE)
 
         h, w = depth_map.shape
         pose = frame_pose if frame_pose is not None else self.pose_matrix
@@ -87,6 +112,21 @@ class DepthCloudWriter:
         n_points = len(pts_f32)
         self._file.write(struct.pack("<I", n_points))
         self._file.write(pts_f32.tobytes())
+
+        # Write RGB if V2
+        if self._v2:
+            if rgb_frame is not None:
+                # Sample BGR frame at valid grid positions, convert to RGB
+                rgb_samples = rgb_frame[vv, uu][:, ::-1]  # BGR → RGB
+                self._file.write(rgb_samples.astype(np.uint8).tobytes())
+            else:
+                logger.warning(
+                    "V2 format active but rgb_frame is None on frame %d; "
+                    "writing zero-filled RGB to preserve binary layout.",
+                    len(self.frame_offsets),
+                )
+                self._file.write(b"\x00" * (n_points * 3))
+
         self.frame_offsets.append((offset, n_points))
 
     def close(self) -> None:
@@ -102,13 +142,20 @@ class DepthCloudWriter:
             )
         for off, n in self.frame_offsets:
             self._file.write(struct.pack("<QI", off, n))
+
         # Update header
         self._file.seek(0)
-        self._file.write(struct.pack("<II", len(self.frame_offsets), index_offset))
+        if self._v2:
+            flags = 0x0001  # has_rgb
+            self._file.write(struct.pack("<IHHI", _V2_MAGIC, 2, flags, index_offset))
+        else:
+            self._file.write(struct.pack("<II", len(self.frame_offsets), index_offset))
+
         self._file.close()
         self._file = None
         logger.info(
-            "Point cloud written: %d frames to %s",
+            "Point cloud written: %d frames (%s) to %s",
             len(self.frame_offsets),
+            "V2+RGB" if self._v2 else "legacy",
             self.output_path,
         )

--- a/src/dino/spatial/depth_localizer.py
+++ b/src/dino/spatial/depth_localizer.py
@@ -96,6 +96,68 @@ class DepthLocalizer(BaseLocalizer):
                 ),
                 frame_idx=frame_idx,
             )
+            # Compute 3D bounding box
+            obj.bbox_3d = self._compute_bbox_3d(
+                obj.bbox_xyxy, depth_map, self._intrinsics, self._pose
+            )
+
             objects.append(obj)
 
         return objects
+
+    @staticmethod
+    def _compute_bbox_3d(
+        bbox_xyxy: np.ndarray,
+        depth_map: np.ndarray,
+        intrinsics: CameraIntrinsics,
+        pose: CameraPose,
+    ) -> np.ndarray | None:
+        """Compute 8 world-space corners of a 3D bounding box.
+
+        Samples depth at the 4 bbox corners + center, uses median as
+        front-face depth, extrudes by a fixed offset for back face.
+        Returns (8, 3) array of world-space corners.
+        """
+        x1, y1, x2, y2 = bbox_xyxy
+        h, w = depth_map.shape
+        cx = (x1 + x2) / 2.0
+        cy = (y1 + y2) / 2.0
+
+        # Sample depth at 4 corners + center
+        sample_points = [
+            (x1, y1), (x2, y1), (x1, y2), (x2, y2), (cx, cy)
+        ]
+        depths = []
+        for u, v in sample_points:
+            ui = max(0, min(int(u), w - 1))
+            vi = max(0, min(int(v), h - 1))
+            d = float(depth_map[vi, ui])
+            if d > _DEPTH_EPSILON:
+                depths.append(d)
+
+        if not depths:
+            logger.debug(
+                "All depth samples below threshold for bbox [%.0f,%.0f,%.0f,%.0f]; "
+                "returning None for bbox_3d",
+                x1, y1, x2, y2,
+            )
+            return None
+
+        front_depth = float(np.median(depths))
+        back_depth = front_depth + 0.05
+
+        # Backproject 4 corners at front and back depths → 8 points
+        # Clamp to image bounds to avoid mirrored world points from negative coords
+        corners_2d = [
+            (max(0.0, min(float(x1), w - 1)), max(0.0, min(float(y1), h - 1))),
+            (max(0.0, min(float(x2), w - 1)), max(0.0, min(float(y1), h - 1))),
+            (max(0.0, min(float(x2), w - 1)), max(0.0, min(float(y2), h - 1))),
+            (max(0.0, min(float(x1), w - 1)), max(0.0, min(float(y2), h - 1))),
+        ]
+        corners_3d = []
+        for depth in (front_depth, back_depth):
+            for u, v in corners_2d:
+                pt = backproject_to_world(u, v, depth, intrinsics, pose)
+                corners_3d.append(pt)
+
+        return np.array(corners_3d)  # (8, 3)

--- a/src/dino/spatial/ego_motion.py
+++ b/src/dino/spatial/ego_motion.py
@@ -83,4 +83,7 @@ class EgoMotionEstimator:
 
     def get_all_poses(self) -> list[dict]:
         """Return list of {position: [x, y, z]} dicts for JSON export."""
-        return [{"position": p[:3, 3].tolist()} for p in self.poses]
+        return [
+            {"position": p[:3, 3].tolist(), "rotation": p[:3, :3].tolist()}
+            for p in self.poses
+        ]

--- a/src/dino/spatial/models.py
+++ b/src/dino/spatial/models.py
@@ -62,3 +62,4 @@ class WorldObject:
     frame_idx: int = 0
     timestamp: float = 0.0
     zone_id: str | None = None
+    bbox_3d: np.ndarray | None = None  # (8,3) world-space corners

--- a/src/dino/spatial/spatial_pipeline.py
+++ b/src/dino/spatial/spatial_pipeline.py
@@ -329,7 +329,7 @@ class SpatialPipeline:
             if self._cloud_writer is not None:
                 depth_map = self._localizer.last_depth_map
                 if depth_map is not None:
-                    self._cloud_writer.write_frame(depth_map, frame_pose)
+                    self._cloud_writer.write_frame(depth_map, frame_pose, rgb_frame=frame)
 
         # Set timestamp on all objects
         for obj in world_objects:
@@ -393,6 +393,7 @@ class SpatialPipeline:
                     "confidence": obj.confidence,
                     "bbox": obj.bbox_xyxy.tolist(),
                     "world_position": obj.world_position.tolist(),
+                    "bbox_3d": obj.bbox_3d.tolist() if obj.bbox_3d is not None else None,
                     "zone_id": obj.zone_id,
                 }
                 for obj in objects

--- a/tests/test_depth_cloud_writer.py
+++ b/tests/test_depth_cloud_writer.py
@@ -174,3 +174,101 @@ class TestDepthCloudWriter:
         data = output.read_bytes()
         num_frames = struct.unpack_from("<I", data, 0)[0]
         assert num_frames == 1
+
+    def test_write_v2_header_magic_and_version(self, tmp_path, intrinsics, pose_matrix):
+        """V2 format should write magic=0x44494E4F, version=2, flags with has_rgb."""
+        output = tmp_path / "cloud_v2.bin"
+        writer = DepthCloudWriter(output, intrinsics, pose_matrix, grid_step=64)
+        writer.open()
+
+        depth_map = np.full((480, 640), 2.0, dtype=np.float32)
+        rgb_frame = np.full((480, 640, 3), 128, dtype=np.uint8)
+        writer.write_frame(depth_map, rgb_frame=rgb_frame)
+        writer.close()
+
+        data = output.read_bytes()
+        magic, version, flags, index_offset = struct.unpack_from("<IHHI", data, 0)
+        assert magic == 0x44494E4F
+        assert version == 2
+        assert flags & 0x01 == 1  # has_rgb bit set
+
+    def test_write_frame_xyzrgb(self, tmp_path, intrinsics, pose_matrix):
+        """Write frame with RGB, read back, verify RGB values match."""
+        output = tmp_path / "cloud_rgb.bin"
+        writer = DepthCloudWriter(output, intrinsics, pose_matrix, grid_step=640)
+        writer.open()
+
+        depth_map = np.full((480, 640), 2.0, dtype=np.float32)
+        # Create a BGR frame (OpenCV default) with known values
+        rgb_frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        rgb_frame[:, :, 0] = 255  # B channel
+        rgb_frame[:, :, 1] = 128  # G channel
+        rgb_frame[:, :, 2] = 64   # R channel
+        writer.write_frame(depth_map, rgb_frame=rgb_frame)
+        writer.close()
+
+        data = output.read_bytes()
+        # Skip 12-byte V2 header
+        n_points = struct.unpack_from("<I", data, 12)[0]
+        assert n_points > 0
+
+        # XYZ floats followed by RGB bytes
+        xyz_offset = 12 + 4  # header + num_points
+        rgb_offset = xyz_offset + n_points * 12  # after float32[N*3]
+        rgb_data = np.frombuffer(data, dtype=np.uint8, count=n_points * 3, offset=rgb_offset)
+        rgb_data = rgb_data.reshape(-1, 3)
+
+        # BGR→RGB conversion: R=64, G=128, B=255
+        assert rgb_data[0, 0] == 64   # R
+        assert rgb_data[0, 1] == 128  # G
+        assert rgb_data[0, 2] == 255  # B
+
+    def test_backward_compat_no_rgb(self, tmp_path, intrinsics, pose_matrix):
+        """Write with rgb_frame=None produces legacy XYZ-only format (8-byte header)."""
+        output = tmp_path / "cloud_legacy.bin"
+        writer = DepthCloudWriter(output, intrinsics, pose_matrix, grid_step=64)
+        writer.open()
+
+        depth_map = np.full((480, 640), 2.0, dtype=np.float32)
+        writer.write_frame(depth_map)
+        writer.close()
+
+        data = output.read_bytes()
+        # Legacy header: u32 num_frames + u32 index_offset (8 bytes)
+        num_frames, index_offset = struct.unpack_from("<II", data, 0)
+        assert num_frames == 1
+        assert index_offset > 8
+
+    def test_round_trip_v2(self, tmp_path, intrinsics, pose_matrix):
+        """Write multiple V2 frames, close, reopen, verify index + data integrity."""
+        output = tmp_path / "cloud_v2_multi.bin"
+        writer = DepthCloudWriter(output, intrinsics, pose_matrix, grid_step=64)
+        writer.open()
+
+        n_frames = 3
+        for i in range(n_frames):
+            depth_map = np.full((480, 640), 1.0 + i, dtype=np.float32)
+            rgb_frame = np.full((480, 640, 3), 50 * (i + 1), dtype=np.uint8)
+            writer.write_frame(depth_map, rgb_frame=rgb_frame)
+        writer.close()
+
+        data = output.read_bytes()
+        magic, version, flags, index_offset = struct.unpack_from("<IHHI", data, 0)
+        assert magic == 0x44494E4F
+        assert version == 2
+        assert flags & 0x01 == 1
+
+        # Verify index entries
+        for i in range(n_frames):
+            entry_off = index_offset + i * 12
+            offset_val = struct.unpack_from("<Q", data, entry_off)[0]
+            n_points = struct.unpack_from("<I", data, entry_off + 8)[0]
+            assert n_points > 0
+            assert offset_val >= 12  # after V2 header
+
+            # Verify we can read back XYZ + RGB at each frame offset
+            frame_n = struct.unpack_from("<I", data, offset_val)[0]
+            assert frame_n == n_points
+            xyz_bytes = n_points * 12  # float32 * 3
+            rgb_bytes = n_points * 3   # uint8 * 3
+            assert offset_val + 4 + xyz_bytes + rgb_bytes <= index_offset

--- a/tests/test_depth_localizer.py
+++ b/tests/test_depth_localizer.py
@@ -10,6 +10,7 @@ import supervision as sv
 from dino.spatial.camera_estimator import estimate_camera
 from dino.spatial.depth_localizer import DepthLocalizer
 from dino.spatial.models import WorldObject
+from dino.spatial.projection import backproject_to_world
 
 
 def _make_detections(n=1, bbox_center=(100, 100), size=40):
@@ -127,3 +128,66 @@ class TestDepthLocalizer:
 
         objects = localizer.localize(dets, frame, frame_idx=0)
         assert objects[0].tracker_id == -1
+
+    def test_compute_bbox_3d_shape(self):
+        """_compute_bbox_3d should return (8, 3) array."""
+        localizer, _ = self._make_localizer(depth_value=2.0)
+        intrinsics, pose = estimate_camera(320, 240)
+        depth_map = np.full((240, 320), 2.0, dtype=np.float32)
+        bbox = np.array([80, 80, 120, 120], dtype=np.float32)
+
+        result = localizer._compute_bbox_3d(bbox, depth_map, intrinsics, pose)
+
+        assert result is not None
+        assert result.shape == (8, 3)
+        assert np.all(np.isfinite(result))
+
+    def test_compute_bbox_3d_encloses_world_position(self):
+        """3D bbox AABB should contain the world_position."""
+        localizer, _ = self._make_localizer(depth_value=2.0)
+        intrinsics, pose = estimate_camera(320, 240)
+        depth_map = np.full((240, 320), 2.0, dtype=np.float32)
+        bbox = np.array([80, 80, 120, 120], dtype=np.float32)
+
+        corners = localizer._compute_bbox_3d(bbox, depth_map, intrinsics, pose)
+
+        # Compute world position at bottom-center of bbox
+        u_center = (80 + 120) / 2.0
+        v_bottom = 120.0
+        world_pos = backproject_to_world(u_center, v_bottom, 2.0, intrinsics, pose)
+
+        # AABB from corners should contain world_pos
+        bbox_min = corners.min(axis=0)
+        bbox_max = corners.max(axis=0)
+        for dim in range(3):
+            assert world_pos[dim] >= bbox_min[dim] - 0.1
+            assert world_pos[dim] <= bbox_max[dim] + 0.1
+
+    def test_compute_bbox_3d_with_flat_depth(self):
+        """Uniform depth should produce corners on two depth planes."""
+        localizer, _ = self._make_localizer(depth_value=3.0)
+        intrinsics, pose = estimate_camera(320, 240)
+        depth_map = np.full((240, 320), 3.0, dtype=np.float32)
+        bbox = np.array([80, 80, 120, 120], dtype=np.float32)
+
+        corners = localizer._compute_bbox_3d(bbox, depth_map, intrinsics, pose)
+        assert corners.shape == (8, 3)
+
+        # With flat depth, front 4 corners should be at ~same depth plane
+        # and back 4 corners should be slightly behind
+        # The Z spread should be small (just the extrusion offset)
+        z_range = corners[:, 2].max() - corners[:, 2].min()
+        assert z_range > 0  # There should be some depth extent
+        assert z_range < 1.0  # But not too much for a 0.05 extrusion
+
+    def test_bbox_3d_in_localize_output(self):
+        """localize() should populate bbox_3d on WorldObjects."""
+        localizer, _ = self._make_localizer(depth_value=2.0)
+        dets = _make_detections(n=1, bbox_center=(160, 120))
+        frame = np.zeros((240, 320, 3), dtype=np.uint8)
+
+        objects = localizer.localize(dets, frame, frame_idx=0)
+
+        assert len(objects) == 1
+        assert objects[0].bbox_3d is not None
+        assert objects[0].bbox_3d.shape == (8, 3)

--- a/tests/test_ego_motion.py
+++ b/tests/test_ego_motion.py
@@ -67,3 +67,18 @@ class TestEgoMotionEstimator:
         pose = estimator.update(frame2)
         # X translation should be non-zero
         assert abs(pose[0, 3]) > 0.01
+
+    def test_get_all_poses_includes_rotation(self, estimator):
+        """Each pose dict should have 'rotation' key with 3x3 list."""
+        rng = np.random.RandomState(42)
+        for _ in range(3):
+            frame = rng.randint(0, 255, (480, 640, 3), dtype=np.uint8)
+            estimator.update(frame)
+        poses = estimator.get_all_poses()
+        assert len(poses) == 3
+        for p in poses:
+            assert "rotation" in p
+            rot = p["rotation"]
+            assert len(rot) == 3
+            for row in rot:
+                assert len(row) == 3

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -35,7 +35,7 @@
         <div class="panel-content" id="annotation-content"></div>
       </div>
       <div class="panel panel-center" id="panel-depth">
-        <div class="panel-label">3D Gaussian Splat</div>
+        <div class="panel-label">3D Spatial View</div>
         <div class="panel-content" id="depth-content"></div>
       </div>
       <div class="panel" id="panel-topdown">

--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -8,6 +8,7 @@ import { ZoneRenderer } from './zone-renderer.js';
 import { ObjectRenderer } from './object-renderer.js';
 import { CameraTrail } from './camera-trail.js';
 import { PointCloudRenderer } from './point-cloud-renderer.js';
+import { CloudObjectRenderer } from './cloud-object-renderer.js';
 import { GaussianSplatRenderer } from './gaussian-splat-renderer.js';
 import { Timeline } from './timeline.js';
 import { VideoPanel } from './video-panel.js';
@@ -99,6 +100,7 @@ async function initViewer(data) {
     let cloudBundle = null;
     let pointCloudRenderer = null;
     let gaussianRenderer = null;
+    let cloudObjectRenderer = null;
 
     if (hasCamera) {
       const cloudContainer = document.getElementById('depth-content');
@@ -136,6 +138,10 @@ async function initViewer(data) {
         setupCloudPanel('pointcloud');
         pointCloudRenderer = new PointCloudRenderer(cloudBundle.scene, metadata.width, metadata.height);
         disposables.push(pointCloudRenderer);
+
+        cloudObjectRenderer = new CloudObjectRenderer(cloudBundle.scene, 1);
+        disposables.push(cloudObjectRenderer);
+
         probeVideoUrl('point_clouds.bin').then(url => {
           if (url && !signal.aborted && pointCloudRenderer) {
             pointCloudRenderer.loadBinary(url).catch(err => {
@@ -200,6 +206,12 @@ async function initViewer(data) {
       // Point cloud
       if (pointCloudRenderer) {
         pointCloudRenderer.updateFrame(timeline ? timeline.currentKeyIndex : 0);
+      }
+
+      // 3D wireframe objects
+      if (cloudObjectRenderer) {
+        const sf = pointCloudRenderer ? pointCloudRenderer.scaleFactor : 1;
+        cloudObjectRenderer.updateObjects(frameData ? frameData.objects : null, sf);
       }
 
       // Timeline UI

--- a/viewer/js/camera-trail.js
+++ b/viewer/js/camera-trail.js
@@ -1,6 +1,7 @@
 /**
  * Camera trail renderer.
- * Shows a polyline of the camera path and an arrow at the current position.
+ * Shows a polyline of the camera path, an arrow at the current position,
+ * and an AxesHelper showing camera orientation.
  */
 import * as THREE from 'three';
 
@@ -21,11 +22,12 @@ export class CameraTrail {
     this.poses = [];
     this.trailLine = null;
     this.arrow = null;
+    this.axesHelper = null;
     this._positions = [];
   }
 
   /**
-   * Set the full trail from poses array [{position: [x, y, z]}, ...].
+   * Set the full trail from poses array [{position: [x, y, z], rotation?: [[r00,r01,r02],[r10,r11,r12],[r20,r21,r22]]}, ...].
    */
   setTrail(poses) {
     this.dispose();
@@ -60,6 +62,11 @@ export class CameraTrail {
     this.arrow.position.copy(this._positions[0]);
     this.arrow.position.y += as;
     this.scene.add(this.arrow);
+
+    // Axes helper showing camera orientation
+    this.axesHelper = new THREE.AxesHelper(as * 0.8);
+    this.axesHelper.position.copy(this._positions[0]);
+    this.scene.add(this.axesHelper);
   }
 
   updateFrame(frameIdx) {
@@ -72,6 +79,28 @@ export class CameraTrail {
     if (this.arrow && this._positions[idx]) {
       this.arrow.position.copy(this._positions[idx]);
       this.arrow.position.y += this.arrowSize;
+    }
+    if (this.axesHelper && this._positions[idx]) {
+      this.axesHelper.position.copy(this._positions[idx]);
+
+      // Apply rotation if available
+      const pose = this.poses[idx];
+      if (pose && pose.rotation && pose.rotation.length === 3 &&
+          pose.rotation.every(row => Array.isArray(row) && row.length === 3)) {
+        const r = pose.rotation;
+        const m = new THREE.Matrix4();
+        // Set rotation part of 4x4 matrix from 3x3 rotation
+        m.set(
+          r[0][0], r[0][1], r[0][2], this.axesHelper.position.x,
+          r[1][0], r[1][1], r[1][2], this.axesHelper.position.y,
+          r[2][0], r[2][1], r[2][2], this.axesHelper.position.z,
+          0, 0, 0, 1
+        );
+        this.axesHelper.matrix.copy(m);
+        this.axesHelper.matrixAutoUpdate = false;
+      } else {
+        this.axesHelper.matrixAutoUpdate = true;
+      }
     }
   }
 
@@ -87,6 +116,11 @@ export class CameraTrail {
       this.arrow.geometry.dispose();
       this.arrow.material.dispose();
       this.arrow = null;
+    }
+    if (this.axesHelper) {
+      this.scene.remove(this.axesHelper);
+      this.axesHelper.dispose();
+      this.axesHelper = null;
     }
     this._positions = [];
     this.poses = [];

--- a/viewer/js/cloud-object-renderer.js
+++ b/viewer/js/cloud-object-renderer.js
@@ -1,0 +1,158 @@
+/**
+ * Wireframe box renderer for 3D detected objects in the point cloud panel.
+ * Renders bbox_3d corners as LineSegments with CSS2D floating labels.
+ */
+import * as THREE from 'three';
+import { CSS2DObject } from 'three/addons/renderers/CSS2DRenderer.js';
+
+const CLASS_COLORS = {
+  person: 0x38bdf8,
+  chair: 0xa78bfa,
+};
+const DEFAULT_COLOR = 0xfb923c;
+
+// 12 edges of a box: front face, back face, connecting edges
+const BOX_EDGES = [
+  0, 1, 1, 2, 2, 3, 3, 0, // front
+  4, 5, 5, 6, 6, 7, 7, 4, // back
+  0, 4, 1, 5, 2, 6, 3, 7, // connecting
+];
+
+const FALLBACK_HALF = 0.15; // half-size of fallback cube in world units
+
+export class CloudObjectRenderer {
+  constructor(scene, scaleFactor) {
+    this.scene = scene;
+    this.scaleFactor = scaleFactor || 1;
+    this.pool = new Map(); // persistent_id -> { group, lines, label, labelDiv, material }
+  }
+
+  _getColor(className) {
+    return CLASS_COLORS[className] || DEFAULT_COLOR;
+  }
+
+  _remap(x, y, z) {
+    const s = this.scaleFactor;
+    return [x * s, z * s, -y * s];
+  }
+
+  _buildBoxGeometry(corners) {
+    const positions = new Float32Array(BOX_EDGES.length * 3);
+    for (let i = 0; i < BOX_EDGES.length; i++) {
+      const ci = BOX_EDGES[i];
+      const [rx, ry, rz] = this._remap(corners[ci][0], corners[ci][1], corners[ci][2]);
+      positions[i * 3] = rx;
+      positions[i * 3 + 1] = ry;
+      positions[i * 3 + 2] = rz;
+    }
+    const geom = new THREE.BufferGeometry();
+    geom.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    return geom;
+  }
+
+  _buildFallbackGeometry(worldPos) {
+    const [cx, cy, cz] = worldPos;
+    const h = FALLBACK_HALF;
+    const corners = [
+      [cx - h, cy - h, cz - h],
+      [cx + h, cy - h, cz - h],
+      [cx + h, cy + h, cz - h],
+      [cx - h, cy + h, cz - h],
+      [cx - h, cy - h, cz + h],
+      [cx + h, cy - h, cz + h],
+      [cx + h, cy + h, cz + h],
+      [cx - h, cy + h, cz + h],
+    ];
+    return this._buildBoxGeometry(corners);
+  }
+
+  _labelTop(corners) {
+    // Average the top 4 corners (indices 4-7) for label position
+    let x = 0, y = 0, z = 0;
+    for (let i = 4; i < 8; i++) {
+      const [rx, ry, rz] = this._remap(corners[i][0], corners[i][1], corners[i][2]);
+      x += rx; y += ry; z += rz;
+    }
+    return new THREE.Vector3(x / 4, y / 4, z / 4);
+  }
+
+  _getOrCreate(persistentId, className) {
+    if (this.pool.has(persistentId)) return this.pool.get(persistentId);
+
+    const group = new THREE.Group();
+    const colorHex = this._getColor(className);
+
+    const material = new THREE.LineBasicMaterial({ color: colorHex, linewidth: 1.5 });
+    // Placeholder geometry — will be replaced on each update
+    const lines = new THREE.LineSegments(new THREE.BufferGeometry(), material);
+    group.add(lines);
+
+    const labelDiv = document.createElement('div');
+    labelDiv.className = 'cloud-label';
+    const borderColor = '#' + colorHex.toString(16).padStart(6, '0');
+    labelDiv.style.cssText = `color: #e2e8f0; font-size: 10px; background: rgba(15,23,42,0.85); padding: 1px 6px; border-radius: 2px; white-space: nowrap; border-left: 3px solid ${borderColor};`;
+    const label = new CSS2DObject(labelDiv);
+    group.add(label);
+
+    this.scene.add(group);
+    const entry = { group, lines, label, labelDiv, material };
+    this.pool.set(persistentId, entry);
+    return entry;
+  }
+
+  updateObjects(frameObjects, scaleFactor) {
+    if (scaleFactor !== undefined) this.scaleFactor = scaleFactor;
+    const seen = new Set();
+
+    if (frameObjects) {
+      for (const obj of frameObjects) {
+        if (obj.persistent_id == null) continue;
+        const id = obj.persistent_id;
+        seen.add(id);
+
+        const entry = this._getOrCreate(id, obj.class_name);
+
+        // Update wireframe geometry
+        const oldGeom = entry.lines.geometry;
+        if (obj.bbox_3d && obj.bbox_3d.length === 8) {
+          entry.lines.geometry = this._buildBoxGeometry(obj.bbox_3d);
+          // Position label at top of bbox
+          const top = this._labelTop(obj.bbox_3d);
+          entry.label.position.copy(top);
+        } else if (obj.world_position) {
+          entry.lines.geometry = this._buildFallbackGeometry(obj.world_position);
+          const [rx, ry, rz] = this._remap(obj.world_position[0], obj.world_position[1], obj.world_position[2] ?? 0);
+          entry.label.position.set(rx, ry + FALLBACK_HALF * this.scaleFactor, rz);
+        }
+        oldGeom.dispose();
+
+        // Update color
+        entry.material.color.setHex(this._getColor(obj.class_name));
+        const borderColor = '#' + this._getColor(obj.class_name).toString(16).padStart(6, '0');
+        entry.labelDiv.style.borderLeftColor = borderColor;
+
+        // Update label text
+        const conf = obj.confidence != null ? ` (${Math.round(obj.confidence * 100)}%)` : '';
+        entry.labelDiv.textContent = `${obj.class_name} #${id}${conf}`;
+
+        entry.group.visible = true;
+      }
+    }
+
+    // Hide unseen
+    for (const [id, entry] of this.pool) {
+      if (!seen.has(id)) {
+        entry.group.visible = false;
+      }
+    }
+  }
+
+  dispose() {
+    for (const entry of this.pool.values()) {
+      this.scene.remove(entry.group);
+      entry.lines.geometry.dispose();
+      entry.material.dispose();
+    }
+    this.pool.clear();
+  }
+}

--- a/viewer/js/point-cloud-renderer.js
+++ b/viewer/js/point-cloud-renderer.js
@@ -1,12 +1,15 @@
 /**
  * Point cloud renderer for the 3D depth panel.
  * Loads binary .bin files and renders accumulated per-frame point clouds.
+ * Supports V2 format with per-vertex RGB colors (magic 0x44494E4F).
  */
 import * as THREE from 'three';
 
-const POINT_COLOR = 0x38bdf8; // sky-400
+const FALLBACK_COLOR = [56 / 255, 189 / 255, 248 / 255]; // sky-400
 const POINT_SIZE = 3;
 const ACCUMULATE_FRAMES = 60; // keep last N frames for dense reconstruction
+
+const MAGIC_V2 = 0x44494E4F; // "DINO" in little-endian
 
 export class PointCloudRenderer {
   constructor(scene, sceneWidth, sceneHeight) {
@@ -20,8 +23,10 @@ export class PointCloudRenderer {
     this._geometry = null;
     this._material = null;
     this._scaleFactor = 0;
-    this._frameCache = new Map(); // frameIdx -> Float32Array (scaled)
+    this._frameCache = new Map(); // frameIdx -> { positions, colors }
     this._lastIdx = -1;
+    this._hasRgb = false;
+    this._headerSize = 8; // legacy default
   }
 
   async loadBinary(url) {
@@ -31,15 +36,40 @@ export class PointCloudRenderer {
     this.buffer = await resp.arrayBuffer();
     console.log('[PointCloud] Loaded:', (this.buffer.byteLength / 1024 / 1024).toFixed(1), 'MB');
     this._parseIndex();
-    console.log('[PointCloud] Frames:', this.numFrames);
+    console.log('[PointCloud] Frames:', this.numFrames, 'RGB:', this._hasRgb);
     this._computeScale();
     this._initPoints();
   }
 
   _parseIndex() {
     const view = new DataView(this.buffer);
-    this.numFrames = view.getUint32(0, true);
-    const indexOffset = view.getUint32(4, true);
+    const magic = view.getUint32(0, true);
+    let indexOffset;
+
+    if (magic === MAGIC_V2) {
+      // V2 header: u32 magic, u16 version, u16 flags, u32 indexOffset
+      this._headerSize = 12;
+      const version = view.getUint16(4, true);
+      if (version !== 2) {
+        throw new Error(`Unsupported point cloud format version: ${version}. Expected 2.`);
+      }
+      const flags = view.getUint16(6, true);
+      this._hasRgb = (flags & 1) !== 0;
+      indexOffset = view.getUint32(8, true);
+      if (indexOffset < this._headerSize || indexOffset > this.buffer.byteLength) {
+        throw new Error(`Corrupted point cloud: invalid index offset ${indexOffset} (file size ${this.buffer.byteLength})`);
+      }
+      // Count frames: each index entry is 12 bytes
+      this.numFrames = Math.floor((this.buffer.byteLength - indexOffset) / 12);
+    } else {
+      // Legacy header: u32 numFrames, u32 indexOffset
+      this._headerSize = 8;
+      this._hasRgb = false;
+      this.numFrames = view.getUint32(0, true);
+      indexOffset = view.getUint32(4, true);
+    }
+
+    // Read frame index (shared between V1 and V2)
     this.frameIndex = [];
     for (let i = 0; i < this.numFrames; i++) {
       const entryOffset = indexOffset + i * 12;
@@ -50,7 +80,6 @@ export class PointCloudRenderer {
   }
 
   _computeScale() {
-    // Sample a few frames to determine extent
     const sampled = [0, Math.floor(this.numFrames / 2), this.numFrames - 1];
     let minX = Infinity, maxX = -Infinity;
     let minY = Infinity, maxY = -Infinity;
@@ -58,7 +87,7 @@ export class PointCloudRenderer {
     for (const fi of sampled) {
       const entry = this.frameIndex[fi];
       if (!entry || entry.numPoints === 0) continue;
-      const dataOffset = entry.offset + 4;
+      const dataOffset = entry.offset + 4; // skip numPoints u32
       const fa = new Float32Array(this.buffer, dataOffset, entry.numPoints * 3);
       for (let i = 0; i < entry.numPoints; i++) {
         const b = i * 3;
@@ -66,6 +95,11 @@ export class PointCloudRenderer {
         if (fa[b+1] < minY) minY = fa[b+1]; if (fa[b+1] > maxY) maxY = fa[b+1];
         if (fa[b+2] < minZ) minZ = fa[b+2]; if (fa[b+2] > maxZ) maxZ = fa[b+2];
       }
+    }
+    if (minX === Infinity) {
+      console.warn('[PointCloud] No valid points found in sampled frames; defaulting scale to 1');
+      this._scaleFactor = 1;
+      return;
     }
     const span = Math.max(maxX - minX, maxY - minY, maxZ - minZ, 0.01);
     this._scaleFactor = Math.min(this.sceneWidth, this.sceneHeight) * 0.35 / span;
@@ -75,7 +109,7 @@ export class PointCloudRenderer {
   _initPoints() {
     this._material = new THREE.PointsMaterial({
       size: POINT_SIZE,
-      color: POINT_COLOR,
+      vertexColors: true,
       sizeAttenuation: true,
       transparent: true,
       opacity: 0.7,
@@ -85,27 +119,42 @@ export class PointCloudRenderer {
       'position',
       new THREE.BufferAttribute(new Float32Array(0), 3)
     );
+    this._geometry.setAttribute(
+      'color',
+      new THREE.BufferAttribute(new Float32Array(0), 3)
+    );
     this.points = new THREE.Points(this._geometry, this._material);
     this.scene.add(this.points);
   }
 
   /**
-   * Read and scale a single frame's points (cached).
+   * Read and scale a single frame's points + colors (cached).
    */
   _getFramePoints(idx) {
     if (this._frameCache.has(idx)) return this._frameCache.get(idx);
     const entry = this.frameIndex[idx];
     if (!entry || entry.numPoints === 0) return null;
 
-    const dataOffset = entry.offset + 4;
-    const raw = new Float32Array(this.buffer, dataOffset, entry.numPoints * 3);
+    const N = entry.numPoints;
+    const dataOffset = entry.offset + 4; // skip numPoints u32
+    const raw = new Float32Array(this.buffer, dataOffset, N * 3);
     const s = this._scaleFactor || 1;
-    const out = new Float32Array(entry.numPoints * 3);
-    for (let i = 0; i < entry.numPoints; i++) {
+    const positions = new Float32Array(N * 3);
+    for (let i = 0; i < N; i++) {
       const b = i * 3;
-      out[b] = raw[b] * s;           // x
-      out[b + 1] = raw[b + 2] * s;   // z -> y (up)
-      out[b + 2] = -raw[b + 1] * s;  // -y -> z
+      positions[b] = raw[b] * s;           // x
+      positions[b + 1] = raw[b + 2] * s;   // z -> y (up)
+      positions[b + 2] = -raw[b + 1] * s;  // -y -> z
+    }
+
+    let colors = null;
+    if (this._hasRgb) {
+      const rgbOffset = entry.offset + 4 + N * 12; // after numPoints u32 + float32[N*3]
+      const rgbRaw = new Uint8Array(this.buffer, rgbOffset, N * 3);
+      colors = new Float32Array(N * 3);
+      for (let i = 0; i < N * 3; i++) {
+        colors[i] = rgbRaw[i] / 255;
+      }
     }
 
     // Evict old cache entries
@@ -113,8 +162,9 @@ export class PointCloudRenderer {
       const oldest = this._frameCache.keys().next().value;
       this._frameCache.delete(oldest);
     }
-    this._frameCache.set(idx, out);
-    return out;
+    const result = { positions, colors };
+    this._frameCache.set(idx, result);
+    return result;
   }
 
   /**
@@ -128,13 +178,13 @@ export class PointCloudRenderer {
 
     // Gather points from last ACCUMULATE_FRAMES frames
     const startIdx = Math.max(0, idx - ACCUMULATE_FRAMES + 1);
-    const arrays = [];
+    const frames = [];
     let totalPoints = 0;
     for (let f = startIdx; f <= idx; f++) {
-      const pts = this._getFramePoints(f);
-      if (pts) {
-        arrays.push(pts);
-        totalPoints += pts.length / 3;
+      const data = this._getFramePoints(f);
+      if (data) {
+        frames.push(data);
+        totalPoints += data.positions.length / 3;
       }
     }
 
@@ -142,23 +192,47 @@ export class PointCloudRenderer {
       this._geometry.setAttribute(
         'position', new THREE.BufferAttribute(new Float32Array(0), 3)
       );
+      this._geometry.setAttribute(
+        'color', new THREE.BufferAttribute(new Float32Array(0), 3)
+      );
       this._geometry.attributes.position.needsUpdate = true;
+      this._geometry.attributes.color.needsUpdate = true;
       return;
     }
 
     // Merge all frame arrays
-    const merged = new Float32Array(totalPoints * 3);
+    const mergedPos = new Float32Array(totalPoints * 3);
+    const mergedCol = new Float32Array(totalPoints * 3);
     let offset = 0;
-    for (const arr of arrays) {
-      merged.set(arr, offset);
-      offset += arr.length;
+    for (const frame of frames) {
+      mergedPos.set(frame.positions, offset);
+      if (frame.colors) {
+        mergedCol.set(frame.colors, offset);
+      } else {
+        // Fallback: sky-blue for legacy frames
+        const n = frame.positions.length;
+        for (let i = 0; i < n; i += 3) {
+          mergedCol[offset + i] = FALLBACK_COLOR[0];
+          mergedCol[offset + i + 1] = FALLBACK_COLOR[1];
+          mergedCol[offset + i + 2] = FALLBACK_COLOR[2];
+        }
+      }
+      offset += frame.positions.length;
     }
 
     this._geometry.setAttribute(
-      'position', new THREE.BufferAttribute(merged, 3)
+      'position', new THREE.BufferAttribute(mergedPos, 3)
+    );
+    this._geometry.setAttribute(
+      'color', new THREE.BufferAttribute(mergedCol, 3)
     );
     this._geometry.attributes.position.needsUpdate = true;
+    this._geometry.attributes.color.needsUpdate = true;
     this._geometry.computeBoundingSphere();
+  }
+
+  get scaleFactor() {
+    return this._scaleFactor;
   }
 
   dispose() {

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -155,3 +155,14 @@ button:hover {
   font-family: monospace;
   white-space: nowrap;
 }
+
+.cloud-label {
+  color: #e2e8f0;
+  font-size: 10px;
+  background: rgba(15, 23, 42, 0.85);
+  padding: 2px 6px;
+  border-radius: 3px;
+  border-left: 3px solid #fb923c;
+  white-space: nowrap;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary

- **Colorized point clouds** — V2 binary format (XYZRGB) with per-vertex colors, backward compat with legacy V1
- **3D wireframe bounding boxes** — computed from depth + 2D detections, rendered as LineSegments with floating CSS2D labels showing class/id/confidence
- **Camera pose axes** — RGB AxesHelper at current position with optional rotation from ego-motion
- **Integration** — CloudObjectRenderer wired into app, panel renamed to "3D Spatial View"

## Test plan

- [x] 250 tests pass (`uv run pytest tests/ -v`)
- [x] New tests for V2 cloud writer (header, XYZRGB, backward compat, round-trip)
- [x] New tests for 3D bbox computation (shape, enclosure, flat depth)
- [x] New test for rotation export in ego-motion
- [ ] Manual: load viewer with new pipeline output, verify colorized points
- [ ] Manual: verify wireframe boxes with labels around detected objects
- [ ] Manual: verify camera axes at current position moving with scrubber
- [ ] Manual: load old V1 .bin file → falls back to sky-blue monochrome
- [ ] Manual: verify 30+ fps with 60-frame accumulation

## Review

Full review triangle completed (2 rounds):
- Code reviewer, silent-failure hunter, code simplifier — all run in parallel
- Round 1: 6 fixes applied (V2 RGB guard, negative coord clamping, header validation, scale guard, rotation validation, index loop dedup)
- Round 2: 2 additional fixes (backprojection coord clamping, indexOffset lower-bound)
- Clean pass on re-review

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)