### PR TITLE
fix: V2 point cloud alignment + camera auto-center

### DIFF
--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -9,7 +9,6 @@ import { ObjectRenderer } from './object-renderer.js';
 import { CameraTrail } from './camera-trail.js';
 import { PointCloudRenderer } from './point-cloud-renderer.js';
 import { CloudObjectRenderer } from './cloud-object-renderer.js';
-import { GaussianSplatRenderer } from './gaussian-splat-renderer.js';
 import { Timeline } from './timeline.js';
 import { VideoPanel } from './video-panel.js';
 
@@ -96,75 +95,53 @@ async function initViewer(data) {
       disposables.push(topDownTrail);
     }
 
-    // --- 3D Gaussian Splat / Point Cloud panel (bare scene — no floor/zones/objects) ---
+    // --- 3D Point Cloud panel (bare scene — no floor/zones/objects) ---
     let cloudBundle = null;
     let pointCloudRenderer = null;
-    let gaussianRenderer = null;
     let cloudObjectRenderer = null;
 
     if (hasCamera) {
       const cloudContainer = document.getElementById('depth-content');
 
-      // Try gaussian splat first, fall back to point cloud
-      const gaussianUrl = await probeVideoUrl('gaussian_splat.ply');
+      // Always use point cloud renderer for center panel
+      cloudBundle = createSceneBundle(
+        cloudContainer, metadata.width, metadata.height, signal, { mode: 'pointcloud' }
+      );
+      disposables.push(cloudBundle.renderer, cloudBundle.labelRenderer);
 
-      function setupCloudPanel(mode) {
-        // Tear down previous bundle if rebuilding on fallback
-        if (cloudBundle) {
-          cloudBundle.renderer.dispose();
-          cloudBundle.renderer.domElement.remove();
-          cloudBundle.labelRenderer.domElement.remove();
-          if (cloudTrail) { cloudTrail.dispose(); cloudTrail = null; }
-          cloudContainer.replaceChildren();
+      // Camera trail
+      if (trailData && trailData.length > 0) {
+        const trailConfig = { scale: Math.min(metadata.width, metadata.height) * 0.35 / 15, arrowSize: 6 };
+        cloudTrail = new CameraTrail(cloudBundle.scene, trailConfig);
+        cloudTrail.setTrail(trailData);
+        disposables.push(cloudTrail);
+      }
+
+      pointCloudRenderer = new PointCloudRenderer(cloudBundle.scene, metadata.width, metadata.height);
+      disposables.push(pointCloudRenderer);
+
+      cloudObjectRenderer = new CloudObjectRenderer(cloudBundle.scene, 1);
+      disposables.push(cloudObjectRenderer);
+
+      probeVideoUrl('point_clouds.bin?v=' + Date.now()).then(url => {
+        if (url && !signal.aborted && pointCloudRenderer) {
+          pointCloudRenderer.loadBinary(url).then(() => {
+            // Reposition camera to center on point cloud
+            const c = pointCloudRenderer.center;
+            if (c && cloudBundle) {
+              const span = Math.min(metadata.width, metadata.height) * 0.35;
+              cloudBundle.camera.position.set(c.x, c.y + span * 0.4, c.z + span * 0.3);
+              cloudBundle.camera.lookAt(c.x, c.y, c.z);
+              cloudBundle.controls.target.set(c.x, c.y, c.z);
+              cloudBundle.controls.update();
+            }
+          }).catch(err => {
+            console.warn('[PointCloud] Load failed:', err.message);
+          });
         }
-        cloudBundle = createSceneBundle(
-          cloudContainer, metadata.width, metadata.height, signal, { mode }
-        );
-        disposables.push(cloudBundle.renderer, cloudBundle.labelRenderer);
-
-        // Camera trail
-        if (trailData && trailData.length > 0) {
-          const trailConfig = mode === 'gaussian'
-            ? { scale: 1, arrowSize: 0.3 }
-            : { scale: Math.min(metadata.width, metadata.height) * 0.35 / 15, arrowSize: 6 };
-          cloudTrail = new CameraTrail(cloudBundle.scene, trailConfig);
-          cloudTrail.setTrail(trailData);
-          disposables.push(cloudTrail);
-        }
-        return cloudBundle;
-      }
-
-      function loadPointCloud() {
-        setupCloudPanel('pointcloud');
-        pointCloudRenderer = new PointCloudRenderer(cloudBundle.scene, metadata.width, metadata.height);
-        disposables.push(pointCloudRenderer);
-
-        cloudObjectRenderer = new CloudObjectRenderer(cloudBundle.scene, 1);
-        disposables.push(cloudObjectRenderer);
-
-        probeVideoUrl('point_clouds.bin').then(url => {
-          if (url && !signal.aborted && pointCloudRenderer) {
-            pointCloudRenderer.loadBinary(url).catch(err => {
-              console.warn('[PointCloud] Load failed:', err.message);
-            });
-          }
-        }).catch(err => {
-          console.warn('[PointCloud] Probe failed:', err.message);
-        });
-      }
-
-      if (gaussianUrl && !signal.aborted) {
-        setupCloudPanel('gaussian');
-        gaussianRenderer = new GaussianSplatRenderer(cloudBundle.scene);
-        disposables.push(gaussianRenderer);
-        gaussianRenderer.load(gaussianUrl).catch(err => {
-          console.warn('[GaussianSplat] Load failed, falling back to point cloud:', err.message);
-          gaussianRenderer.dispose();
-          loadPointCloud();
-        });
-      } else {
-        loadPointCloud();
-      }
+      }).catch(err => {
+        console.warn('[PointCloud] Probe failed:', err.message);
+      });
     }
 
     // --- UI elements ---

--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -102,6 +102,7 @@ async function initViewer(data) {
 
     if (hasCamera) {
       const cloudContainer = document.getElementById('depth-content');
+      const sceneSpan = Math.min(metadata.width, metadata.height) * 0.35;
 
       // Always use point cloud renderer for center panel
       cloudBundle = createSceneBundle(
@@ -111,7 +112,7 @@ async function initViewer(data) {
 
       // Camera trail
       if (trailData && trailData.length > 0) {
-        const trailConfig = { scale: Math.min(metadata.width, metadata.height) * 0.35 / 15, arrowSize: 6 };
+        const trailConfig = { scale: sceneSpan / 15, arrowSize: 6 };
         cloudTrail = new CameraTrail(cloudBundle.scene, trailConfig);
         cloudTrail.setTrail(trailData);
         disposables.push(cloudTrail);
@@ -123,20 +124,19 @@ async function initViewer(data) {
       cloudObjectRenderer = new CloudObjectRenderer(cloudBundle.scene, 1);
       disposables.push(cloudObjectRenderer);
 
-      probeVideoUrl('point_clouds.bin?v=' + Date.now()).then(url => {
+      probeVideoUrl('point_clouds.bin').then(url => {
         if (url && !signal.aborted && pointCloudRenderer) {
           pointCloudRenderer.loadBinary(url).then(() => {
+            if (signal.aborted) return;
             // Reposition camera to center on point cloud
             const c = pointCloudRenderer.center;
             if (c && cloudBundle) {
-              const span = Math.min(metadata.width, metadata.height) * 0.35;
-              cloudBundle.camera.position.set(c.x, c.y + span * 0.4, c.z + span * 0.3);
-              cloudBundle.camera.lookAt(c.x, c.y, c.z);
+              cloudBundle.camera.position.set(c.x, c.y + sceneSpan * 0.4, c.z + sceneSpan * 0.3);
               cloudBundle.controls.target.set(c.x, c.y, c.z);
               cloudBundle.controls.update();
             }
           }).catch(err => {
-            console.warn('[PointCloud] Load failed:', err.message);
+            console.error('[PointCloud] Load failed:', err);
           });
         }
       }).catch(err => {

--- a/viewer/js/point-cloud-renderer.js
+++ b/viewer/js/point-cloud-renderer.js
@@ -32,7 +32,7 @@ export class PointCloudRenderer {
 
   async loadBinary(url) {
     console.log('[PointCloud] Fetching:', url);
-    const resp = await fetch(url);
+    const resp = await fetch(url, { cache: 'no-store' });
     if (!resp.ok) throw new Error(`Failed to load point cloud: ${resp.status}`);
     this.buffer = await resp.arrayBuffer();
     console.log('[PointCloud] Loaded:', (this.buffer.byteLength / 1024 / 1024).toFixed(1), 'MB');
@@ -176,7 +176,7 @@ export class PointCloudRenderer {
       if (rgbEnd > this.buffer.byteLength) {
         console.warn(`[PointCloud] Frame ${idx}: RGB data truncated`);
       } else {
-        const rgbRaw = new Uint8Array(this.buffer, rgbOffset, N * 3);
+        const rgbRaw = new Uint8Array(this.buffer.slice(rgbOffset, rgbEnd));
         colors = new Float32Array(N * 3);
         for (let i = 0; i < N * 3; i++) {
           colors[i] = rgbRaw[i] / 255;

--- a/viewer/js/point-cloud-renderer.js
+++ b/viewer/js/point-cloud-renderer.js
@@ -89,8 +89,13 @@ export class PointCloudRenderer {
       const entry = this.frameIndex[fi];
       if (!entry || entry.numPoints === 0) continue;
       const dataOffset = entry.offset + 4; // skip numPoints u32
+      const end = dataOffset + entry.numPoints * 12;
+      if (end > this.buffer.byteLength) {
+        console.warn(`[PointCloud] Frame ${fi}: data extends beyond buffer`);
+        continue;
+      }
       // Use slice() for alignment safety — V2 RGB bytes can cause unaligned offsets
-      const fa = new Float32Array(this.buffer.slice(dataOffset, dataOffset + entry.numPoints * 12));
+      const fa = new Float32Array(this.buffer.slice(dataOffset, end));
       for (let i = 0; i < entry.numPoints; i++) {
         const b = i * 3;
         if (fa[b] < minX) minX = fa[b]; if (fa[b] > maxX) maxX = fa[b];
@@ -101,6 +106,7 @@ export class PointCloudRenderer {
     if (minX === Infinity) {
       console.warn('[PointCloud] No valid points found in sampled frames; defaulting scale to 1');
       this._scaleFactor = 1;
+      this._center = { x: 0, y: 0, z: 0 };
       return;
     }
     const span = Math.max(maxX - minX, maxY - minY, maxZ - minZ, 0.01);
@@ -147,8 +153,13 @@ export class PointCloudRenderer {
 
     const N = entry.numPoints;
     const dataOffset = entry.offset + 4; // skip numPoints u32
+    const xyzEnd = dataOffset + N * 12;
+    if (xyzEnd > this.buffer.byteLength) {
+      console.warn(`[PointCloud] Frame ${idx}: XYZ data truncated`);
+      return null;
+    }
     // Use slice() for alignment safety — V2 RGB bytes can cause unaligned offsets
-    const raw = new Float32Array(this.buffer.slice(dataOffset, dataOffset + N * 12));
+    const raw = new Float32Array(this.buffer.slice(dataOffset, xyzEnd));
     const s = this._scaleFactor || 1;
     const positions = new Float32Array(N * 3);
     for (let i = 0; i < N; i++) {
@@ -161,10 +172,15 @@ export class PointCloudRenderer {
     let colors = null;
     if (this._hasRgb) {
       const rgbOffset = entry.offset + 4 + N * 12; // after numPoints u32 + float32[N*3]
-      const rgbRaw = new Uint8Array(this.buffer, rgbOffset, N * 3);
-      colors = new Float32Array(N * 3);
-      for (let i = 0; i < N * 3; i++) {
-        colors[i] = rgbRaw[i] / 255;
+      const rgbEnd = rgbOffset + N * 3;
+      if (rgbEnd > this.buffer.byteLength) {
+        console.warn(`[PointCloud] Frame ${idx}: RGB data truncated`);
+      } else {
+        const rgbRaw = new Uint8Array(this.buffer, rgbOffset, N * 3);
+        colors = new Float32Array(N * 3);
+        for (let i = 0; i < N * 3; i++) {
+          colors[i] = rgbRaw[i] / 255;
+        }
       }
     }
 
@@ -192,10 +208,14 @@ export class PointCloudRenderer {
     const frames = [];
     let totalPoints = 0;
     for (let f = startIdx; f <= idx; f++) {
-      const data = this._getFramePoints(f);
-      if (data) {
-        frames.push(data);
-        totalPoints += data.positions.length / 3;
+      try {
+        const data = this._getFramePoints(f);
+        if (data) {
+          frames.push(data);
+          totalPoints += data.positions.length / 3;
+        }
+      } catch (err) {
+        console.warn(`[PointCloud] Failed to read frame ${f}:`, err.message);
       }
     }
 

--- a/viewer/js/point-cloud-renderer.js
+++ b/viewer/js/point-cloud-renderer.js
@@ -27,6 +27,7 @@ export class PointCloudRenderer {
     this._lastIdx = -1;
     this._hasRgb = false;
     this._headerSize = 8; // legacy default
+    this._center = null; // {x, y, z} in scaled Three.js coords
   }
 
   async loadBinary(url) {
@@ -88,7 +89,8 @@ export class PointCloudRenderer {
       const entry = this.frameIndex[fi];
       if (!entry || entry.numPoints === 0) continue;
       const dataOffset = entry.offset + 4; // skip numPoints u32
-      const fa = new Float32Array(this.buffer, dataOffset, entry.numPoints * 3);
+      // Use slice() for alignment safety — V2 RGB bytes can cause unaligned offsets
+      const fa = new Float32Array(this.buffer.slice(dataOffset, dataOffset + entry.numPoints * 12));
       for (let i = 0; i < entry.numPoints; i++) {
         const b = i * 3;
         if (fa[b] < minX) minX = fa[b]; if (fa[b] > maxX) maxX = fa[b];
@@ -103,7 +105,15 @@ export class PointCloudRenderer {
     }
     const span = Math.max(maxX - minX, maxY - minY, maxZ - minZ, 0.01);
     this._scaleFactor = Math.min(this.sceneWidth, this.sceneHeight) * 0.35 / span;
-    console.log('[PointCloud] Full extent:', span.toFixed(2), 'scale:', this._scaleFactor.toFixed(1));
+    // Center in Three.js coords: (x*s, z*s, -y*s)
+    const s = this._scaleFactor;
+    this._center = {
+      x: ((minX + maxX) / 2) * s,
+      y: ((minZ + maxZ) / 2) * s,
+      z: -((minY + maxY) / 2) * s,
+    };
+    console.log('[PointCloud] Full extent:', span.toFixed(2), 'scale:', this._scaleFactor.toFixed(1),
+      'center:', this._center.x.toFixed(0), this._center.y.toFixed(0), this._center.z.toFixed(0));
   }
 
   _initPoints() {
@@ -137,7 +147,8 @@ export class PointCloudRenderer {
 
     const N = entry.numPoints;
     const dataOffset = entry.offset + 4; // skip numPoints u32
-    const raw = new Float32Array(this.buffer, dataOffset, N * 3);
+    // Use slice() for alignment safety — V2 RGB bytes can cause unaligned offsets
+    const raw = new Float32Array(this.buffer.slice(dataOffset, dataOffset + N * 12));
     const s = this._scaleFactor || 1;
     const positions = new Float32Array(N * 3);
     for (let i = 0; i < N; i++) {
@@ -233,6 +244,10 @@ export class PointCloudRenderer {
 
   get scaleFactor() {
     return this._scaleFactor;
+  }
+
+  get center() {
+    return this._center;
   }
 
   dispose() {


### PR DESCRIPTION
## Summary
- Fix `Float32Array` alignment error in V2 point cloud format — RGB bytes cause unaligned offsets for subsequent frames
- Auto-center 3D camera on point cloud after binary load (computes center during scale calculation)
- Remove Gaussian splat fallback — always use point cloud renderer for center panel

Fixes the "start offset of Float32Array should be a multiple of 4" error that prevented V2 XYZRGB point clouds from rendering correctly.

## Test plan
- [x] V2 binary loads without console errors
- [x] RGB colors visible in 3D spatial view panel
- [x] Camera auto-centers on point cloud (no tiny/off-center view)
- [x] Scrubbing through frames shows accumulated colorized reconstruction
- [ ] Legacy V1 files still load with fallback sky-blue color

🤖 Generated with [Claude Code](https://claude.com/claude-code)