### PR TITLE
feat: dense room reconstruction (COLMAP MVS + SLAM3R)

### DIFF
--- a/modal_colmap_dense.py
+++ b/modal_colmap_dense.py
@@ -50,7 +50,8 @@ def run_colmap_dense(video_bytes: bytes, video_name: str = "input.mp4"):
         shutil.rmtree(work)
     work.mkdir(parents=True)
 
-    # 1. Save video
+    # 1. Save video (sanitize filename to prevent path traversal)
+    video_name = Path(video_name).name or "input.mp4"
     video_path = work / video_name
     video_path.write_bytes(video_bytes)
     print(f"[1/7] Video saved: {len(video_bytes) / 1024 / 1024:.1f}MB")
@@ -58,12 +59,16 @@ def run_colmap_dense(video_bytes: bytes, video_name: str = "input.mp4"):
     # 2. Extract frames (5fps, 800px wide)
     input_dir = work / "images"
     input_dir.mkdir()
-    subprocess.run([
-        "ffmpeg", "-i", str(video_path),
-        "-vf", "fps=5,scale=800:-2",
-        "-q:v", "2",
-        str(input_dir / "frame_%04d.jpg"),
-    ], check=True, capture_output=True)
+    try:
+        subprocess.run([
+            "ffmpeg", "-i", str(video_path),
+            "-vf", "fps=5,scale=800:-2",
+            "-q:v", "2",
+            str(input_dir / "frame_%04d.jpg"),
+        ], check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as e:
+        print(f"ffmpeg stderr: {e.stderr[-2000:]}")
+        raise RuntimeError(f"Frame extraction failed: {e.stderr[-500:]}") from e
     n = len(list(input_dir.glob("*.jpg")))
     print(f"[2/7] Extracted {n} frames")
 
@@ -147,8 +152,14 @@ def _run_colmap(command: str, args: list, label: str):
         capture_output=True, text=True,
     )
     if result.returncode != 0:
-        print(f"{label} stderr: {result.stderr[-3000:]}")
-        raise RuntimeError(f"COLMAP {command} failed (exit {result.returncode})")
+        print(f"{label} stdout: {result.stdout[-2000:]}")
+        print(f"{label} stderr: {result.stderr[-2000:]}")
+        raise RuntimeError(
+            f"COLMAP {command} failed (exit {result.returncode}): "
+            f"{result.stderr[-500:]}"
+        )
+    if result.stderr:
+        print(f"{label} warnings: {result.stderr[-1000:]}")
 
 
 @app.local_entrypoint()

--- a/modal_colmap_dense.py
+++ b/modal_colmap_dense.py
@@ -1,0 +1,166 @@
+"""Modal script: Dense room reconstruction via COLMAP MVS.
+
+Runs COLMAP SfM + patch_match_stereo + stereo_fusion on a Modal A100 GPU
+to produce a dense colored point cloud (fused.ply) from a walkthrough video.
+
+Usage:
+    modal run modal_colmap_dense.py --video /Users/heng/Downloads/test_rest.mp4
+"""
+import modal
+from pathlib import Path
+
+app = modal.App("colmap-dense")
+
+colmap_image = (
+    modal.Image.from_registry("nvidia/cuda:11.8.0-devel-ubuntu22.04", add_python="3.10")
+    .apt_install(
+        "git", "ffmpeg", "imagemagick", "g++", "ninja-build",
+        "cmake", "libboost-all-dev", "libfreeimage-dev", "libgoogle-glog-dev",
+        "libgflags-dev", "libglew-dev", "libsqlite3-dev", "libceres-dev",
+        "qtbase5-dev", "libqt5opengl5-dev", "libcgal-dev", "libflann-dev",
+    )
+    .run_commands(
+        # Build COLMAP from source with CUDA support for patch_match_stereo
+        "git clone --branch 3.9.1 https://github.com/colmap/colmap.git /tmp/colmap"
+        " && mkdir /tmp/colmap/build && cd /tmp/colmap/build"
+        " && cmake .. -GNinja -DCMAKE_CUDA_ARCHITECTURES=80 -DCMAKE_BUILD_TYPE=Release"
+        " && ninja -j$(nproc) && ninja install"
+        " && rm -rf /tmp/colmap"
+    )
+    .run_commands("pip install plyfile tqdm numpy opencv-python-headless")
+)
+
+vol = modal.Volume.from_name("colmap-dense-workspace", create_if_missing=True)
+VOLUME_PATH = "/workspace"
+
+
+@app.function(
+    image=colmap_image,
+    gpu="A100",
+    timeout=2400,  # 40 min
+    volumes={VOLUME_PATH: vol},
+)
+def run_colmap_dense(video_bytes: bytes, video_name: str = "input.mp4"):
+    """Full pipeline: frames -> COLMAP SfM -> dense MVS -> fused.ply."""
+    import subprocess
+    import shutil
+
+    work = Path(VOLUME_PATH) / "dense_run"
+    if work.exists():
+        shutil.rmtree(work)
+    work.mkdir(parents=True)
+
+    # 1. Save video
+    video_path = work / video_name
+    video_path.write_bytes(video_bytes)
+    print(f"[1/7] Video saved: {len(video_bytes) / 1024 / 1024:.1f}MB")
+
+    # 2. Extract frames (5fps, 800px wide)
+    input_dir = work / "images"
+    input_dir.mkdir()
+    subprocess.run([
+        "ffmpeg", "-i", str(video_path),
+        "-vf", "fps=5,scale=800:-2",
+        "-q:v", "2",
+        str(input_dir / "frame_%04d.jpg"),
+    ], check=True, capture_output=True)
+    n = len(list(input_dir.glob("*.jpg")))
+    print(f"[2/7] Extracted {n} frames")
+
+    # 3. COLMAP feature extraction (GPU SIFT)
+    db_path = work / "database.db"
+    sparse_dir = work / "sparse"
+    sparse_dir.mkdir()
+
+    _run_colmap("feature_extractor", [
+        "--database_path", str(db_path),
+        "--image_path", str(input_dir),
+        "--ImageReader.single_camera", "1",
+        "--SiftExtraction.use_gpu", "1",
+    ], "Feature extraction")
+    print("[3/7] Feature extraction done")
+
+    # 4. Sequential matching (GPU)
+    _run_colmap("sequential_matcher", [
+        "--database_path", str(db_path),
+        "--SiftMatching.use_gpu", "1",
+    ], "Matching")
+    print("[4/7] Matching done")
+
+    # 5. Sparse reconstruction
+    _run_colmap("mapper", [
+        "--database_path", str(db_path),
+        "--image_path", str(input_dir),
+        "--output_path", str(sparse_dir),
+    ], "Sparse reconstruction")
+    print("[5/7] Sparse reconstruction done")
+
+    # Find the reconstruction (usually sparse/0/)
+    recon_dir = sparse_dir / "0"
+    if not recon_dir.exists():
+        recons = sorted(sparse_dir.iterdir())
+        if not recons:
+            raise RuntimeError("COLMAP mapper produced no reconstruction")
+        recon_dir = recons[0]
+
+    # 6. Image undistorter (needed for dense reconstruction)
+    dense_dir = work / "dense"
+    _run_colmap("image_undistorter", [
+        "--image_path", str(input_dir),
+        "--input_path", str(recon_dir),
+        "--output_path", str(dense_dir),
+        "--output_type", "COLMAP",
+    ], "Undistortion")
+
+    # Patch match stereo (dense depth maps, GPU)
+    _run_colmap("patch_match_stereo", [
+        "--workspace_path", str(dense_dir),
+        "--PatchMatchStereo.gpu_index", "0",
+        "--PatchMatchStereo.geom_consistency", "true",
+    ], "Patch match stereo")
+    print("[6/7] Dense depth maps done")
+
+    # 7. Stereo fusion -> fused.ply
+    fused_ply = dense_dir / "fused.ply"
+    _run_colmap("stereo_fusion", [
+        "--workspace_path", str(dense_dir),
+        "--output_path", str(fused_ply),
+    ], "Stereo fusion")
+    print("[7/7] Stereo fusion done")
+
+    if not fused_ply.exists():
+        raise RuntimeError("stereo_fusion did not produce fused.ply")
+
+    out_bytes = fused_ply.read_bytes()
+    print(f"Result: fused.ply ({len(out_bytes) / 1024 / 1024:.1f}MB)")
+
+    vol.commit()
+    return out_bytes
+
+
+def _run_colmap(command: str, args: list, label: str):
+    """Run a COLMAP command with error handling."""
+    import subprocess
+
+    result = subprocess.run(
+        ["colmap", command] + args,
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"{label} stderr: {result.stderr[-3000:]}")
+        raise RuntimeError(f"COLMAP {command} failed (exit {result.returncode})")
+
+
+@app.local_entrypoint()
+def main(video: str = "/Users/heng/Downloads/test_rest.mp4"):
+    """Upload video, run dense reconstruction on A100, download fused.ply."""
+    p = Path(video)
+    if not p.exists():
+        raise FileNotFoundError(f"Not found: {video}")
+
+    print(f"Uploading {p.name} ({p.stat().st_size / 1024 / 1024:.1f}MB)...")
+    data = run_colmap_dense.remote(p.read_bytes(), p.name)
+
+    out_path = Path("viewer/point_cloud.ply")
+    out_path.write_bytes(data)
+    print(f"Saved: {out_path} ({len(data) / 1024 / 1024:.1f}MB)")

--- a/modal_slam3r.py
+++ b/modal_slam3r.py
@@ -63,7 +63,8 @@ def run_slam3r(video_bytes: bytes, video_name: str = "input.mp4"):
         shutil.rmtree(work)
     work.mkdir(parents=True)
 
-    # 1. Save video
+    # 1. Save video (sanitize filename to prevent path traversal)
+    video_name = Path(video_name).name or "input.mp4"
     video_path = work / video_name
     video_path.write_bytes(video_bytes)
     print(f"[1/3] Video saved: {len(video_bytes) / 1024 / 1024:.1f}MB")
@@ -71,16 +72,25 @@ def run_slam3r(video_bytes: bytes, video_name: str = "input.mp4"):
     # 2. Extract frames (5fps, 800px wide)
     frames_dir = work / "frames"
     frames_dir.mkdir()
-    subprocess.run([
-        "ffmpeg", "-i", str(video_path),
-        "-vf", "fps=5,scale=800:-2",
-        "-q:v", "2",
-        str(frames_dir / "frame_%04d.jpg"),
-    ], check=True, capture_output=True)
+    try:
+        subprocess.run([
+            "ffmpeg", "-i", str(video_path),
+            "-vf", "fps=5,scale=800:-2",
+            "-q:v", "2",
+            str(frames_dir / "frame_%04d.jpg"),
+        ], check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as e:
+        print(f"ffmpeg stderr: {e.stderr[-2000:]}")
+        raise RuntimeError(f"Frame extraction failed: {e.stderr[-500:]}") from e
     n = len(list(frames_dir.glob("*.jpg")))
     print(f"[2/3] Extracted {n} frames")
 
-    # 3. Run SLAM3R reconstruction
+    # 3. Clean stale results from previous runs
+    results_dir = Path("/opt/slam3r/results")
+    if results_dir.exists():
+        shutil.rmtree(results_dir)
+
+    # Run SLAM3R reconstruction
     result = subprocess.run([
         "python", "/opt/slam3r/recon.py",
         "--img_dir", str(frames_dir),
@@ -102,10 +112,17 @@ def run_slam3r(video_bytes: bytes, video_name: str = "input.mp4"):
         + glob.glob(str(work / "**/*_recon.ply"), recursive=True)
         + glob.glob("/opt/slam3r/results/**/*.ply", recursive=True)
     )
+    print(f"[SLAM3R] PLY search found {len(ply_candidates)} candidates: {ply_candidates}")
     if not ply_candidates:
-        raise RuntimeError("SLAM3R did not produce a PLY file")
+        raise RuntimeError(
+            "SLAM3R did not produce a PLY file. "
+            "Searched: /opt/slam3r/results/**/*_recon.ply, "
+            f"{work}/**/*_recon.ply, /opt/slam3r/results/**/*.ply"
+        )
 
     ply_path = Path(ply_candidates[0])
+    if len(ply_candidates) > 1:
+        print(f"[SLAM3R] Multiple PLY files found, using first: {ply_path}")
     out_bytes = ply_path.read_bytes()
     print(f"Result: {ply_path.name} ({len(out_bytes) / 1024 / 1024:.1f}MB)")
 

--- a/modal_slam3r.py
+++ b/modal_slam3r.py
@@ -1,0 +1,128 @@
+"""Modal script: Dense room reconstruction via SLAM3R (CVPR 2025).
+
+SLAM3R reconstructs dense colored point clouds from monocular video
+without camera calibration. Runs on a Modal A100 GPU.
+
+Usage:
+    modal run modal_slam3r.py --video /Users/heng/Downloads/test_rest.mp4
+"""
+import modal
+from pathlib import Path
+
+app = modal.App("slam3r")
+
+slam3r_image = (
+    modal.Image.from_registry("nvidia/cuda:11.8.0-devel-ubuntu22.04", add_python="3.11")
+    .apt_install("git", "ffmpeg", "g++", "ninja-build", "cmake")
+    .env({"TORCH_CUDA_ARCH_LIST": "8.0", "CUDA_HOME": "/usr/local/cuda"})
+    .run_commands(
+        "pip install torch==2.5.0 torchvision==0.20.0 --index-url https://download.pytorch.org/whl/cu118"
+    )
+    .run_commands(
+        "pip install xformers==0.0.28.post2 --index-url https://download.pytorch.org/whl/cu118"
+    )
+    .run_commands(
+        "git clone https://github.com/PKU-VCL-3DV/SLAM3R.git /opt/slam3r"
+    )
+    .run_commands(
+        "pip install roma scipy einops trimesh matplotlib tqdm"
+        " opencv-python-headless 'huggingface-hub[torch]>=0.22' 'pyglet<2' tensorboard open3d plyfile"
+    )
+    # Build curope CUDA kernels for A100 (sm_80)
+    .run_commands(
+        "cd /opt/slam3r/slam3r/pos_embed/curope"
+        " && sed -i 's/-arch=native/-arch=sm_80/' setup.py"
+        " && python setup.py build_ext --inplace"
+    )
+    # Bake model weights into image (~4GB, downloads once during build)
+    .run_commands(
+        'python -c "from huggingface_hub import snapshot_download;'
+        "snapshot_download('siyan824/slam3r_i2p');"
+        "snapshot_download('siyan824/slam3r_l2w')\""
+    )
+)
+
+vol = modal.Volume.from_name("slam3r-workspace", create_if_missing=True)
+VOLUME_PATH = "/workspace"
+
+
+@app.function(
+    image=slam3r_image,
+    gpu="A100",
+    timeout=3600,  # 60 min
+    volumes={VOLUME_PATH: vol},
+)
+def run_slam3r(video_bytes: bytes, video_name: str = "input.mp4"):
+    """Full pipeline: video -> frames -> SLAM3R -> dense PLY."""
+    import subprocess
+    import shutil
+    import glob
+
+    work = Path(VOLUME_PATH) / "slam3r_run"
+    if work.exists():
+        shutil.rmtree(work)
+    work.mkdir(parents=True)
+
+    # 1. Save video
+    video_path = work / video_name
+    video_path.write_bytes(video_bytes)
+    print(f"[1/3] Video saved: {len(video_bytes) / 1024 / 1024:.1f}MB")
+
+    # 2. Extract frames (5fps, 800px wide)
+    frames_dir = work / "frames"
+    frames_dir.mkdir()
+    subprocess.run([
+        "ffmpeg", "-i", str(video_path),
+        "-vf", "fps=5,scale=800:-2",
+        "-q:v", "2",
+        str(frames_dir / "frame_%04d.jpg"),
+    ], check=True, capture_output=True)
+    n = len(list(frames_dir.glob("*.jpg")))
+    print(f"[2/3] Extracted {n} frames")
+
+    # 3. Run SLAM3R reconstruction
+    result = subprocess.run([
+        "python", "/opt/slam3r/recon.py",
+        "--img_dir", str(frames_dir),
+        "--test_name", "modal_run",
+        "--num_points_save", "2000000",
+        "--buffer_strategy", "reservoir",
+        "--keyframe_stride", "3",
+    ], capture_output=True, text=True, cwd="/opt/slam3r")
+
+    if result.returncode != 0:
+        print(f"SLAM3R stdout: {result.stdout[-3000:]}")
+        print(f"SLAM3R stderr: {result.stderr[-3000:]}")
+        raise RuntimeError(f"SLAM3R reconstruction failed (exit {result.returncode})")
+    print("[3/3] SLAM3R reconstruction done")
+
+    # Find the output PLY (SLAM3R outputs *_recon.ply in results/)
+    ply_candidates = (
+        glob.glob("/opt/slam3r/results/**/*_recon.ply", recursive=True)
+        + glob.glob(str(work / "**/*_recon.ply"), recursive=True)
+        + glob.glob("/opt/slam3r/results/**/*.ply", recursive=True)
+    )
+    if not ply_candidates:
+        raise RuntimeError("SLAM3R did not produce a PLY file")
+
+    ply_path = Path(ply_candidates[0])
+    out_bytes = ply_path.read_bytes()
+    print(f"Result: {ply_path.name} ({len(out_bytes) / 1024 / 1024:.1f}MB)")
+
+    vol.commit()
+    return out_bytes
+
+
+@app.local_entrypoint()
+def main(video: str = "/Users/heng/Downloads/test_rest.mp4"):
+    """Upload video, run SLAM3R on A100, download PLY."""
+    p = Path(video)
+    if not p.exists():
+        raise FileNotFoundError(f"Not found: {video}")
+
+    print(f"Uploading {p.name} ({p.stat().st_size / 1024 / 1024:.1f}MB)...")
+    data = run_slam3r.remote(p.read_bytes(), p.name)
+
+    out_path = Path("viewer/point_cloud.ply")
+    out_path.write_bytes(data)
+    print(f"Saved: {out_path} ({len(data) / 1024 / 1024:.1f}MB)")

--- a/modal_slam3r.py
+++ b/modal_slam3r.py
@@ -103,7 +103,10 @@ def run_slam3r(video_bytes: bytes, video_name: str = "input.mp4"):
     if result.returncode != 0:
         print(f"SLAM3R stdout: {result.stdout[-3000:]}")
         print(f"SLAM3R stderr: {result.stderr[-3000:]}")
-        raise RuntimeError(f"SLAM3R reconstruction failed (exit {result.returncode})")
+        raise RuntimeError(
+            f"SLAM3R reconstruction failed (exit {result.returncode}): "
+            f"{result.stderr[-500:]}"
+        )
     print("[3/3] SLAM3R reconstruction done")
 
     # Find the output PLY (SLAM3R outputs *_recon.ply in results/)

--- a/scripts/run_reconstruction.py
+++ b/scripts/run_reconstruction.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Orchestrator: tries SLAM3R first, falls back to COLMAP dense MVS.
+
+Usage:
+    python scripts/run_reconstruction.py /path/to/video.mp4
+    python scripts/run_reconstruction.py --video /path/to/video.mp4
+"""
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Dense room reconstruction via Modal")
+    parser.add_argument("video", nargs="?", help="Path to input video")
+    parser.add_argument("--video", dest="video_flag", help="Path to input video (alternative)")
+    args = parser.parse_args()
+
+    video = args.video or args.video_flag
+    if not video:
+        parser.error("Video path required")
+
+    video_path = Path(video)
+    if not video_path.exists():
+        print(f"Error: video not found: {video_path}", file=sys.stderr)
+        sys.exit(1)
+
+    project_root = Path(__file__).resolve().parent.parent
+
+    # Try SLAM3R first (better quality for monocular video)
+    print(f"=== Trying SLAM3R reconstruction ===")
+    result = subprocess.run(
+        ["modal", "run", str(project_root / "modal_slam3r.py"), "--video", str(video_path)],
+        cwd=str(project_root),
+    )
+
+    if result.returncode == 0:
+        print("\nSLAM3R reconstruction succeeded!")
+        return
+
+    # Fall back to COLMAP dense MVS
+    print(f"\n=== SLAM3R failed (exit {result.returncode}), trying COLMAP dense ===")
+    result = subprocess.run(
+        ["modal", "run", str(project_root / "modal_colmap_dense.py"), "--video", str(video_path)],
+        cwd=str(project_root),
+    )
+
+    if result.returncode == 0:
+        print("\nCOLMAP dense reconstruction succeeded!")
+    else:
+        print(f"\nCOLMAP dense also failed (exit {result.returncode})", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -50,6 +50,7 @@ function positionCameraOnCloud(renderer, bundle, sceneSpan) {
 }
 
 async function loadPointCloud(renderer, bundle, sceneSpan, signal) {
+  let loadError = null;
   try {
     const plyUrl = await probeVideoUrl('point_cloud.ply');
     if (plyUrl && !signal.aborted && renderer) {
@@ -58,16 +59,23 @@ async function loadPointCloud(renderer, bundle, sceneSpan, signal) {
       return;
     }
   } catch (err) {
-    console.warn('[PointCloud] PLY probe/load failed:', err.message);
+    loadError = err;
+    console.error('[PointCloud] PLY load failed:', err);
   }
   try {
     const binUrl = await probeVideoUrl('point_clouds.bin');
     if (binUrl && !signal.aborted && renderer) {
       await renderer.loadBinary(binUrl);
       if (!signal.aborted) positionCameraOnCloud(renderer, bundle, sceneSpan);
+      return;
     }
   } catch (err) {
-    console.warn('[PointCloud] BIN probe/load failed:', err.message);
+    loadError = err;
+    console.error('[PointCloud] BIN load failed:', err);
+  }
+  if (loadError) {
+    const status = document.getElementById('status');
+    if (status) status.textContent += ' | Point cloud unavailable';
   }
 }
 
@@ -156,7 +164,8 @@ async function initViewer(data) {
       disposables.push(cloudObjectRenderer);
 
       // Try PLY first (SLAM3R/COLMAP dense output), then .bin (legacy)
-      loadPointCloud(pointCloudRenderer, cloudBundle, sceneSpan, signal);
+      loadPointCloud(pointCloudRenderer, cloudBundle, sceneSpan, signal)
+        .catch(err => console.error('[PointCloud] Unexpected error:', err));
     }
 
     // --- UI elements ---

--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -40,6 +40,37 @@ function cleanup() {
   }
 }
 
+function positionCameraOnCloud(renderer, bundle, sceneSpan) {
+  const c = renderer.center;
+  if (c && bundle) {
+    bundle.camera.position.set(c.x, c.y + sceneSpan * 0.4, c.z + sceneSpan * 0.3);
+    bundle.controls.target.set(c.x, c.y, c.z);
+    bundle.controls.update();
+  }
+}
+
+async function loadPointCloud(renderer, bundle, sceneSpan, signal) {
+  try {
+    const plyUrl = await probeVideoUrl('point_cloud.ply');
+    if (plyUrl && !signal.aborted && renderer) {
+      await renderer.loadPLY(plyUrl);
+      if (!signal.aborted) positionCameraOnCloud(renderer, bundle, sceneSpan);
+      return;
+    }
+  } catch (err) {
+    console.warn('[PointCloud] PLY probe/load failed:', err.message);
+  }
+  try {
+    const binUrl = await probeVideoUrl('point_clouds.bin');
+    if (binUrl && !signal.aborted && renderer) {
+      await renderer.loadBinary(binUrl);
+      if (!signal.aborted) positionCameraOnCloud(renderer, bundle, sceneSpan);
+    }
+  } catch (err) {
+    console.warn('[PointCloud] BIN probe/load failed:', err.message);
+  }
+}
+
 async function initViewer(data) {
   cleanup();
   abortController = new AbortController();
@@ -124,24 +155,8 @@ async function initViewer(data) {
       cloudObjectRenderer = new CloudObjectRenderer(cloudBundle.scene, 1);
       disposables.push(cloudObjectRenderer);
 
-      probeVideoUrl('point_clouds.bin').then(url => {
-        if (url && !signal.aborted && pointCloudRenderer) {
-          pointCloudRenderer.loadBinary(url).then(() => {
-            if (signal.aborted) return;
-            // Reposition camera to center on point cloud
-            const c = pointCloudRenderer.center;
-            if (c && cloudBundle) {
-              cloudBundle.camera.position.set(c.x, c.y + sceneSpan * 0.4, c.z + sceneSpan * 0.3);
-              cloudBundle.controls.target.set(c.x, c.y, c.z);
-              cloudBundle.controls.update();
-            }
-          }).catch(err => {
-            console.error('[PointCloud] Load failed:', err);
-          });
-        }
-      }).catch(err => {
-        console.warn('[PointCloud] Probe failed:', err.message);
-      });
+      // Try PLY first (SLAM3R/COLMAP dense output), then .bin (legacy)
+      loadPointCloud(pointCloudRenderer, cloudBundle, sceneSpan, signal);
     }
 
     // --- UI elements ---

--- a/viewer/js/point-cloud-renderer.js
+++ b/viewer/js/point-cloud-renderer.js
@@ -54,9 +54,18 @@ export class PointCloudRenderer {
     });
 
     const posAttr = geometry.getAttribute('position');
+    if (!posAttr) {
+      throw new Error('PLY file has no vertex position data — file may be corrupt');
+    }
     const colAttr = geometry.getAttribute('color');
     const N = posAttr.count;
     console.log(`[PointCloud] PLY loaded: ${N} points, hasColor: ${!!colAttr}`);
+
+    if (N === 0) {
+      console.warn('[PointCloud] PLY file contains no points');
+      this._center = { x: 0, y: 0, z: 0 };
+      return;
+    }
 
     // Compute bounding box for auto-scale
     geometry.computeBoundingBox();
@@ -206,6 +215,11 @@ export class PointCloudRenderer {
   }
 
   _initPoints() {
+    // Clean up previous mesh if re-initializing (e.g., switching PLY → BIN)
+    if (this.points) this.scene.remove(this.points);
+    if (this._geometry) this._geometry.dispose();
+    if (this._material) this._material.dispose();
+
     this._material = new THREE.PointsMaterial({
       size: POINT_SIZE,
       vertexColors: true,

--- a/viewer/js/point-cloud-renderer.js
+++ b/viewer/js/point-cloud-renderer.js
@@ -4,10 +4,13 @@
  * Supports V2 format with per-vertex RGB colors (magic 0x44494E4F).
  */
 import * as THREE from 'three';
+import { PLYLoader } from 'three/addons/loaders/PLYLoader.js';
 
 const FALLBACK_COLOR = [56 / 255, 189 / 255, 248 / 255]; // sky-400
 const POINT_SIZE = 3;
 const ACCUMULATE_FRAMES = 60; // keep last N frames for dense reconstruction
+const SAT_BOOST = 1.3;
+const GAMMA = 0.85;
 
 const MAGIC_V2 = 0x44494E4F; // "DINO" in little-endian
 
@@ -28,6 +31,7 @@ export class PointCloudRenderer {
     this._hasRgb = false;
     this._headerSize = 8; // legacy default
     this._center = null; // {x, y, z} in scaled Three.js coords
+    this._isPLY = false;
   }
 
   async loadBinary(url) {
@@ -40,6 +44,85 @@ export class PointCloudRenderer {
     console.log('[PointCloud] Frames:', this.numFrames, 'RGB:', this._hasRgb);
     this._computeScale();
     this._initPoints();
+  }
+
+  async loadPLY(url) {
+    console.log('[PointCloud] Loading PLY:', url);
+    const loader = new PLYLoader();
+    const geometry = await new Promise((resolve, reject) => {
+      loader.load(url, resolve, undefined, reject);
+    });
+
+    const posAttr = geometry.getAttribute('position');
+    const colAttr = geometry.getAttribute('color');
+    const N = posAttr.count;
+    console.log(`[PointCloud] PLY loaded: ${N} points, hasColor: ${!!colAttr}`);
+
+    // Compute bounding box for auto-scale
+    geometry.computeBoundingBox();
+    const bb = geometry.boundingBox;
+    const span = Math.max(
+      bb.max.x - bb.min.x,
+      bb.max.y - bb.min.y,
+      bb.max.z - bb.min.z,
+      0.01
+    );
+    const s = Math.min(this.sceneWidth, this.sceneHeight) * 0.35 / span;
+    this._scaleFactor = s;
+
+    // Transform positions: (x*s, z*s, -y*s) for Three.js Y-up
+    const positions = new Float32Array(N * 3);
+    for (let i = 0; i < N; i++) {
+      const x = posAttr.getX(i);
+      const y = posAttr.getY(i);
+      const z = posAttr.getZ(i);
+      positions[i * 3]     = x * s;
+      positions[i * 3 + 1] = z * s;
+      positions[i * 3 + 2] = -y * s;
+    }
+
+    // Process colors with saturation boost + gamma
+    const colors = new Float32Array(N * 3);
+    if (colAttr) {
+      for (let i = 0; i < N; i++) {
+        let r = colAttr.getX(i);
+        let g = colAttr.getY(i);
+        let b = colAttr.getZ(i);
+        // Saturation boost
+        const gray = 0.299 * r + 0.587 * g + 0.114 * b;
+        r = Math.min(1, gray + (r - gray) * SAT_BOOST);
+        g = Math.min(1, gray + (g - gray) * SAT_BOOST);
+        b = Math.min(1, gray + (b - gray) * SAT_BOOST);
+        // Gamma correction
+        colors[i * 3]     = Math.pow(Math.max(0, r), GAMMA);
+        colors[i * 3 + 1] = Math.pow(Math.max(0, g), GAMMA);
+        colors[i * 3 + 2] = Math.pow(Math.max(0, b), GAMMA);
+      }
+    } else {
+      for (let i = 0; i < N * 3; i += 3) {
+        colors[i]     = FALLBACK_COLOR[0];
+        colors[i + 1] = FALLBACK_COLOR[1];
+        colors[i + 2] = FALLBACK_COLOR[2];
+      }
+    }
+
+    // Compute center in transformed coords
+    let cx = 0, cy = 0, cz = 0;
+    for (let i = 0; i < N; i++) {
+      cx += positions[i * 3];
+      cy += positions[i * 3 + 1];
+      cz += positions[i * 3 + 2];
+    }
+    this._center = { x: cx / N, y: cy / N, z: cz / N };
+
+    // Initialize points mesh
+    this._initPoints();
+    this._geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    this._geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+    this._geometry.computeBoundingSphere();
+
+    this._isPLY = true;
+    console.log(`[PointCloud] PLY ready: scale=${s.toFixed(2)}, center=(${this._center.x.toFixed(0)}, ${this._center.y.toFixed(0)}, ${this._center.z.toFixed(0)})`);
   }
 
   _parseIndex() {
@@ -198,6 +281,7 @@ export class PointCloudRenderer {
    * Update point cloud — accumulate last N frames for dense reconstruction.
    */
   updateFrame(frameIdx) {
+    if (this._isPLY) return; // static PLY — no per-frame updates
     if (!this.buffer || !this.frameIndex.length || !this._geometry) return;
     const idx = Math.min(frameIdx, this.frameIndex.length - 1);
     if (idx === this._lastIdx) return;


### PR DESCRIPTION
## Summary

- Add PLY loading support to the 3D viewer with priority probe (`.ply` → `.bin` fallback)
- Add COLMAP dense MVS pipeline (`modal_colmap_dense.py`) — GPU SIFT + patch_match_stereo + stereo_fusion
- Add SLAM3R pipeline (`modal_slam3r.py`) — CVPR 2025 monocular video → dense point cloud
- Add orchestrator script (`scripts/run_reconstruction.py`) — tries SLAM3R first, falls back to COLMAP

Fixes #44

## Test plan

- [ ] `modal run modal_colmap_dense.py --video test_rest.mp4` → produces `viewer/point_cloud.ply`
- [ ] `modal run modal_slam3r.py --video test_rest.mp4` → produces `viewer/point_cloud.ply`
- [ ] `cd viewer && python serve.py` → dense RGB point cloud visible in center panel
- [ ] Verify `.bin` fallback still works when no PLY present
- [ ] Verify orbit/pan/zoom controls work with dense PLY cloud
- [ ] `python scripts/run_reconstruction.py --video test_rest.mp4` → orchestrator fallback logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)